### PR TITLE
remove unnecessary argument for normalize_base2k tmp bytes funcs

### DIFF
--- a/spqlios/arithmetic/vec_znx.c
+++ b/spqlios/arithmetic/vec_znx.c
@@ -75,13 +75,9 @@ EXPORT void vec_znx_normalize_base2k(const MODULE* module,                      
                                         tmp_space);
 }
 
-EXPORT uint64_t vec_znx_normalize_base2k_tmp_bytes(const MODULE* module,  // N
-                                                   uint64_t res_size,     // res size
-                                                   uint64_t inp_size      // inp size
+EXPORT uint64_t vec_znx_normalize_base2k_tmp_bytes(const MODULE* module  // N
 ) {
-  return module->func.vec_znx_normalize_base2k_tmp_bytes(module,    // N
-                                                         res_size,  // res size
-                                                         inp_size   // inp size
+  return module->func.vec_znx_normalize_base2k_tmp_bytes(module  // N
   );
 }
 
@@ -247,9 +243,7 @@ EXPORT void vec_znx_normalize_base2k_ref(const MODULE* module,                  
   }
 }
 
-EXPORT uint64_t vec_znx_normalize_base2k_tmp_bytes_ref(const MODULE* module,  // N
-                                                       uint64_t res_size,     // res size
-                                                       uint64_t inp_size      // inp size
+EXPORT uint64_t vec_znx_normalize_base2k_tmp_bytes_ref(const MODULE* module  // N
 ) {
   const uint64_t nn = module->nn;
   return nn * sizeof(int64_t);
@@ -257,16 +251,12 @@ EXPORT uint64_t vec_znx_normalize_base2k_tmp_bytes_ref(const MODULE* module,  //
 
 // alias have to be defined in this unit: do not move
 EXPORT uint64_t fft64_vec_znx_big_normalize_base2k_tmp_bytes(  //
-    const MODULE* module,                                      // N
-    uint64_t res_size,                                         // res size
-    uint64_t inp_size                                          // inp size
+    const MODULE* module                                       // N
     ) __attribute((alias("vec_znx_normalize_base2k_tmp_bytes_ref")));
 
 // alias have to be defined in this unit: do not move
 EXPORT uint64_t fft64_vec_znx_big_range_normalize_base2k_tmp_bytes(  //
-    const MODULE* module,                                            // N
-    uint64_t res_size,                                               // res size
-    uint64_t inp_size                                                // inp size
+    const MODULE* module                                             // N
     ) __attribute((alias("vec_znx_normalize_base2k_tmp_bytes_ref")));
 
 EXPORT void std_free(void* addr) { free(addr); }

--- a/spqlios/arithmetic/vec_znx_arithmetic.h
+++ b/spqlios/arithmetic/vec_znx_arithmetic.h
@@ -107,9 +107,7 @@ EXPORT void vec_znx_normalize_base2k(const MODULE* module,                      
 );
 
 /** @brief returns the minimal byte length of scratch space for vec_znx_normalize_base2k */
-EXPORT uint64_t vec_znx_normalize_base2k_tmp_bytes(const MODULE* module,  // N
-                                                   uint64_t res_size,     // res size
-                                                   uint64_t inp_size      // inp size
+EXPORT uint64_t vec_znx_normalize_base2k_tmp_bytes(const MODULE* module  // N
 );
 
 /** @brief sets res = a . X^p */
@@ -234,9 +232,7 @@ EXPORT void vec_znx_big_normalize_base2k(const MODULE* module,                  
 );
 
 /** @brief returns the minimal byte length of scratch space for vec_znx_big_normalize_base2k */
-EXPORT uint64_t vec_znx_big_normalize_base2k_tmp_bytes(const MODULE* module,  // N
-                                                       uint64_t res_size,     // res size
-                                                       uint64_t inp_size      // inp size
+EXPORT uint64_t vec_znx_big_normalize_base2k_tmp_bytes(const MODULE* module  // N
 );
 
 /** @brief apply a svp product, result = ppol * a, presented in DFT space */
@@ -257,9 +253,7 @@ EXPORT void vec_znx_big_range_normalize_base2k(                                 
 
 /** @brief returns the minimal byte length of scratch space for vec_znx_big_range_normalize_base2k */
 EXPORT uint64_t vec_znx_big_range_normalize_base2k_tmp_bytes(  //
-    const MODULE* module,                                      // N
-    uint64_t res_size,                                         // res size
-    uint64_t inp_size                                          // inp size
+    const MODULE* module                                       // N
 );
 
 /** @brief sets res = a . X^p */

--- a/spqlios/arithmetic/vec_znx_arithmetic_private.h
+++ b/spqlios/arithmetic/vec_znx_arithmetic_private.h
@@ -215,9 +215,7 @@ EXPORT void vec_znx_normalize_base2k_ref(const MODULE* module,                  
                                          uint8_t* tmp_space                                 // scratch space
 );
 
-EXPORT uint64_t vec_znx_normalize_base2k_tmp_bytes_ref(const MODULE* module,  // N
-                                                       uint64_t res_size,     // res size
-                                                       uint64_t inp_size      // inp size
+EXPORT uint64_t vec_znx_normalize_base2k_tmp_bytes_ref(const MODULE* module  // N
 );
 
 EXPORT void vec_znx_rotate_ref(const MODULE* module,                              // N
@@ -290,9 +288,7 @@ EXPORT void fft64_vec_znx_big_normalize_base2k(const MODULE* module,            
 );
 
 /** @brief returns the minimal byte length of scratch space for vec_znx_big_normalize_base2k */
-EXPORT uint64_t fft64_vec_znx_big_normalize_base2k_tmp_bytes(const MODULE* module,  // N
-                                                             uint64_t res_size,     // res size
-                                                             uint64_t inp_size      // inp size
+EXPORT uint64_t fft64_vec_znx_big_normalize_base2k_tmp_bytes(const MODULE* module  // N
 
 );
 
@@ -306,9 +302,7 @@ EXPORT void fft64_vec_znx_big_range_normalize_base2k(const MODULE* module,      
 );
 
 /** @brief returns the minimal byte length of scratch space for vec_znx_big_range_normalize_base2k */
-EXPORT uint64_t fft64_vec_znx_big_range_normalize_base2k_tmp_bytes(const MODULE* module,  // N
-                                                                   uint64_t res_size,     // res size
-                                                                   uint64_t inp_size      // inp size
+EXPORT uint64_t fft64_vec_znx_big_range_normalize_base2k_tmp_bytes(const MODULE* module  // N
 );
 
 EXPORT void fft64_vec_znx_dft(const MODULE* module,                             // N

--- a/spqlios/arithmetic/vec_znx_big.c
+++ b/spqlios/arithmetic/vec_znx_big.c
@@ -209,13 +209,9 @@ EXPORT void vec_znx_big_normalize_base2k(const MODULE* module,                  
                                             tmp_space);
 }
 
-EXPORT uint64_t vec_znx_big_normalize_base2k_tmp_bytes(const MODULE* module,  // N
-                                                       uint64_t res_size,     // res size
-                                                       uint64_t inp_size      // inp size
+EXPORT uint64_t vec_znx_big_normalize_base2k_tmp_bytes(const MODULE* module  // N
 ) {
-  return module->func.vec_znx_big_normalize_base2k_tmp_bytes(module,    // N
-                                                             res_size,  // res size
-                                                             inp_size   // inp size
+  return module->func.vec_znx_big_normalize_base2k_tmp_bytes(module  // N
   );
 }
 
@@ -233,11 +229,9 @@ EXPORT void vec_znx_big_range_normalize_base2k(                                 
 
 /** @brief returns the minimal byte length of scratch space for vec_znx_big_range_normalize_base2k */
 EXPORT uint64_t vec_znx_big_range_normalize_base2k_tmp_bytes(  //
-    const MODULE* module,                                      // N
-    uint64_t res_size,                                         // res size
-    uint64_t inp_size                                          // inp size
+    const MODULE* module                                       // N
 ) {
-  return module->func.vec_znx_big_range_normalize_base2k_tmp_bytes(module, res_size, inp_size);
+  return module->func.vec_znx_big_range_normalize_base2k_tmp_bytes(module);
 }
 
 EXPORT void fft64_vec_znx_big_normalize_base2k(const MODULE* module,                              // N

--- a/test/spqlios_vec_znx_big_test.cpp
+++ b/test/spqlios_vec_znx_big_test.cpp
@@ -152,7 +152,7 @@ static void test_vec_znx_big_normalize(VEC_ZNX_BIG_NORMALIZE_BASE2K_F normalize,
       uint64_t r_sl = n + 3;
       def_rand_big(a, n, sa);
       znx_vec_i64_layout r(n, sr, r_sl);
-      std::vector<uint8_t> tmp_space(normalize_tmp_bytes(module, sr, sa));
+      std::vector<uint8_t> tmp_space(normalize_tmp_bytes(module));
       normalize(module, k, r.data(), sr, r_sl, a.data, sa, tmp_space.data());
     }
   }
@@ -189,7 +189,7 @@ static void test_vec_znx_big_range_normalize(  //
       znx_vec_i64_layout r(n, sr, r_sl);
       znx_vec_i64_layout r2(n, sr, r_sl);
       // tmp_space is large-enough for both
-      std::vector<uint8_t> tmp_space(normalize_tmp_bytes(module, sr, sa));
+      std::vector<uint8_t> tmp_space(normalize_tmp_bytes(module));
       normalize(module, k, r.data(), sr, r_sl, a.data, a_start, a_end, a_step, tmp_space.data());
       fft64_vec_znx_big_normalize_base2k(module, k, r2.data(), sr, r_sl, aextr.data, range_size, tmp_space.data());
       for (uint64_t i = 0; i < sr; ++i) {

--- a/test/spqlios_vec_znx_test.cpp
+++ b/test/spqlios_vec_znx_test.cpp
@@ -472,7 +472,7 @@ void test_vec_znx_normalize_outplace(ACTUAL_FCN test_normalize, TMP_BYTES_FNC tm
           uint64_t b_sl = uniform_u64_bits(3) * 5 + n;
           znx_vec_i64_layout lb(n, sb, b_sl);
 
-          const uint64_t tmp_size = tmp_bytes(mod, sa, sa);
+          const uint64_t tmp_size = tmp_bytes(mod);
           uint8_t* tmp = new uint8_t[tmp_size];
           test_normalize(mod,                  // N
                          base_k,               // base_k
@@ -517,7 +517,7 @@ void test_vec_znx_normalize_inplace(ACTUAL_FCN test_normalize, TMP_BYTES_FNC tmp
         }
         vec_poly_normalize(base_k, la_norm);
 
-        const uint64_t tmp_size = tmp_bytes(mod, sa, sa);
+        const uint64_t tmp_size = tmp_bytes(mod);
         uint8_t* tmp = new uint8_t[tmp_size];
         test_normalize(mod,                  // N
                        base_k,               // base_k


### PR DESCRIPTION
For issue https://github.com/tfhe/spqlios-arithmetic/issues/28

Removed two unnecessary inputs from the normalize_base2k  tmp bytes functions.