### PR TITLE
changes for spqlios-allocators

### DIFF
--- a/spqlios/arithmetic/module_api.c
+++ b/spqlios/arithmetic/module_api.c
@@ -24,10 +24,6 @@ static void fill_generic_virtual_table(MODULE* module) {
 static void fill_fft64_virtual_table(MODULE* module) {
   // TODO add default ref handler here
   // module->func.vec_znx_dft = ...;
-  module->func.vmp_pmat_alloc = fft64_vmp_pmat_alloc;
-  module->func.vec_znx_dft_alloc = fft64_vec_znx_dft_alloc;
-  module->func.vec_znx_big_alloc = fft64_vec_znx_big_alloc;
-  module->func.svp_ppol_alloc = fft64_svp_ppol_alloc;
   module->func.vec_znx_big_normalize_base2k = fft64_vec_znx_big_normalize_base2k;
   module->func.vec_znx_big_normalize_base2k_tmp_bytes = fft64_vec_znx_big_normalize_base2k_tmp_bytes;
   module->func.vec_znx_big_range_normalize_base2k = fft64_vec_znx_big_range_normalize_base2k;
@@ -55,6 +51,18 @@ static void fill_fft64_virtual_table(MODULE* module) {
   module->func.vmp_apply_dft_tmp_bytes = fft64_vmp_apply_dft_tmp_bytes;
   module->func.vmp_apply_dft_to_dft = fft64_vmp_apply_dft_to_dft_ref;
   module->func.vmp_apply_dft_to_dft_tmp_bytes = fft64_vmp_apply_dft_to_dft_tmp_bytes;
+  module->func.bytes_of_vec_znx_dft = fft64_bytes_of_vec_znx_dft;
+  module->func.bytes_of_vec_znx_dft = fft64_bytes_of_vec_znx_dft;
+  module->func.bytes_of_vec_znx_dft = fft64_bytes_of_vec_znx_dft;
+  module->func.bytes_of_vec_znx_big = fft64_bytes_of_vec_znx_big;
+  module->func.new_vec_znx_big = fft64_new_vec_znx_big;
+  module->func.delete_vec_znx_big = fft64_delete_vec_znx_big;
+  module->func.bytes_of_svp_ppol = fft64_bytes_of_svp_ppol;
+  module->func.new_svp_ppol = fft64_new_svp_ppol;
+  module->func.delete_svp_ppol = fft64_delete_svp_ppol;
+  module->func.bytes_of_vmp_pmat = fft64_bytes_of_vmp_pmat;
+  module->func.new_vmp_pmat = fft64_new_vmp_pmat;
+  module->func.delete_vmp_pmat = fft64_delete_vmp_pmat;
   if (CPU_SUPPORTS("avx2")) {
     // TODO add avx handlers here
     // TODO: enable when avx implementation is done

--- a/spqlios/arithmetic/module_api.c
+++ b/spqlios/arithmetic/module_api.c
@@ -55,14 +55,8 @@ static void fill_fft64_virtual_table(MODULE* module) {
   module->func.bytes_of_vec_znx_dft = fft64_bytes_of_vec_znx_dft;
   module->func.bytes_of_vec_znx_dft = fft64_bytes_of_vec_znx_dft;
   module->func.bytes_of_vec_znx_big = fft64_bytes_of_vec_znx_big;
-  module->func.new_vec_znx_big = fft64_new_vec_znx_big;
-  module->func.delete_vec_znx_big = fft64_delete_vec_znx_big;
   module->func.bytes_of_svp_ppol = fft64_bytes_of_svp_ppol;
-  module->func.new_svp_ppol = fft64_new_svp_ppol;
-  module->func.delete_svp_ppol = fft64_delete_svp_ppol;
   module->func.bytes_of_vmp_pmat = fft64_bytes_of_vmp_pmat;
-  module->func.new_vmp_pmat = fft64_new_vmp_pmat;
-  module->func.delete_vmp_pmat = fft64_delete_vmp_pmat;
   if (CPU_SUPPORTS("avx2")) {
     // TODO add avx handlers here
     // TODO: enable when avx implementation is done

--- a/spqlios/arithmetic/scalar_vector_product.c
+++ b/spqlios/arithmetic/scalar_vector_product.c
@@ -4,10 +4,6 @@
 
 EXPORT uint64_t bytes_of_svp_ppol(const MODULE* module) { return module->func.bytes_of_svp_ppol(module); }
 
-EXPORT SVP_PPOL* new_svp_ppol(const MODULE* module) { return module->func.new_svp_ppol(module); }
-
-EXPORT void delete_svp_ppol(SVP_PPOL* ppol) { spqlios_free(ppol); }
-
 EXPORT uint64_t fft64_bytes_of_svp_ppol(const MODULE* module) { return module->nn * sizeof(double); }
 
 EXPORT SVP_PPOL* fft64_new_svp_ppol(const MODULE* module) { return spqlios_alloc(fft64_bytes_of_svp_ppol(module)); }

--- a/spqlios/arithmetic/scalar_vector_product.c
+++ b/spqlios/arithmetic/scalar_vector_product.c
@@ -2,45 +2,17 @@
 
 #include "vec_znx_arithmetic_private.h"
 
-EXPORT uint64_t bytes_of_svp_ppol(const MODULE* module) {
-  return module->func.bytes_of_svp_ppol(module);
-}
+EXPORT uint64_t bytes_of_svp_ppol(const MODULE* module) { return module->func.bytes_of_svp_ppol(module); }
 
-EXPORT SVP_PPOL* new_svp_ppol(const MODULE* module) {
-  return module->func.new_svp_ppol(module);
-}
+EXPORT SVP_PPOL* new_svp_ppol(const MODULE* module) { return module->func.new_svp_ppol(module); }
 
-EXPORT void delete_svp_ppol(SVP_PPOL* ppol) {
-  spqlios_free(ppol);
-}
+EXPORT void delete_svp_ppol(SVP_PPOL* ppol) { spqlios_free(ppol); }
 
-EXPORT uint64_t fft64_bytes_of_svp_ppol(const MODULE* module) {
-  return module->nn * sizeof(double);
-}
+EXPORT uint64_t fft64_bytes_of_svp_ppol(const MODULE* module) { return module->nn * sizeof(double); }
 
-EXPORT SVP_PPOL* fft64_new_svp_ppol(const MODULE* module) {
-  return spqlios_alloc(fft64_bytes_of_svp_ppol(module));
-}
+EXPORT SVP_PPOL* fft64_new_svp_ppol(const MODULE* module) { return spqlios_alloc(fft64_bytes_of_svp_ppol(module)); }
 
-EXPORT void fft64_delete_svp_ppol(SVP_PPOL* ppol) {
-  spqlios_free(ppol);
-}
-
-EXPORT SVP_PPOL* svp_ppol_spqlios_alloc(const MODULE* module) {
-#ifndef NDEBUG
-  return spqlios_debug_alloc(fft64_bytes_of_svp_ppol(module));
-#else
-  return spqlios_alloc(fft64_bytes_of_svp_ppol(module));
-#endif
-}
-
-EXPORT void svp_ppol_spqlios_free(SVP_PPOL* ppol) {
-#ifndef NDEBUG
-  spqlios_debug_free(ppol);
-#else
-  spqlios_free(ppol);
-#endif
-}
+EXPORT void fft64_delete_svp_ppol(SVP_PPOL* ppol) { spqlios_free(ppol); }
 
 // public wrappers
 EXPORT void svp_prepare(const MODULE* module,  // N

--- a/spqlios/arithmetic/scalar_vector_product.c
+++ b/spqlios/arithmetic/scalar_vector_product.c
@@ -2,16 +2,44 @@
 
 #include "vec_znx_arithmetic_private.h"
 
-EXPORT SVP_PPOL* svp_ppol_alloc(const MODULE* module)  // N
-{
-  return module->func.svp_ppol_alloc(module);
+EXPORT uint64_t bytes_of_svp_ppol(const MODULE* module) {
+  return module->func.bytes_of_svp_ppol(module);
 }
 
-EXPORT SVP_PPOL* fft64_svp_ppol_alloc(const MODULE* module) {
-  const uint64_t rsize = module->nn * sizeof(double);
-  SVP_PPOL* reps = aligned_alloc(64, (rsize + 63) & (UINT64_C(-64)));
-  if (reps == 0) FATAL_ERROR("Out of memory");
-  return reps;
+EXPORT SVP_PPOL* new_svp_ppol(const MODULE* module) {
+  return module->func.new_svp_ppol(module);
+}
+
+EXPORT void delete_svp_ppol(SVP_PPOL* ppol) {
+  spqlios_free(ppol);
+}
+
+EXPORT uint64_t fft64_bytes_of_svp_ppol(const MODULE* module) {
+  return module->nn * sizeof(double);
+}
+
+EXPORT SVP_PPOL* fft64_new_svp_ppol(const MODULE* module) {
+  return spqlios_alloc(fft64_bytes_of_svp_ppol(module));
+}
+
+EXPORT void fft64_delete_svp_ppol(SVP_PPOL* ppol) {
+  spqlios_free(ppol);
+}
+
+EXPORT SVP_PPOL* svp_ppol_spqlios_alloc(const MODULE* module) {
+#ifndef NDEBUG
+  return spqlios_debug_alloc(fft64_bytes_of_svp_ppol(module));
+#else
+  return spqlios_alloc(fft64_bytes_of_svp_ppol(module));
+#endif
+}
+
+EXPORT void svp_ppol_spqlios_free(SVP_PPOL* ppol) {
+#ifndef NDEBUG
+  spqlios_debug_free(ppol);
+#else
+  spqlios_free(ppol);
+#endif
 }
 
 // public wrappers

--- a/spqlios/arithmetic/vec_znx.c
+++ b/spqlios/arithmetic/vec_znx.c
@@ -259,7 +259,6 @@ EXPORT uint64_t fft64_vec_znx_big_range_normalize_base2k_tmp_bytes(  //
     const MODULE* module                                             // N
     ) __attribute((alias("vec_znx_normalize_base2k_tmp_bytes_ref")));
 
-EXPORT void std_free(void* addr) { free(addr); }  // moshih: delete
 EXPORT void spqlios_free(void* addr) { free(addr); }
 
 EXPORT void* spqlios_alloc(uint64_t size) {

--- a/spqlios/arithmetic/vec_znx.c
+++ b/spqlios/arithmetic/vec_znx.c
@@ -259,7 +259,18 @@ EXPORT uint64_t fft64_vec_znx_big_range_normalize_base2k_tmp_bytes(  //
     const MODULE* module                                             // N
     ) __attribute((alias("vec_znx_normalize_base2k_tmp_bytes_ref")));
 
-EXPORT void std_free(void* addr) { free(addr); }
+EXPORT void std_free(void* addr) { free(addr); }  // moshih: delete
+EXPORT void spqlios_free(void* addr) { free(addr); }
+
+EXPORT void* spqlios_alloc(uint64_t size) {
+  VEC_ZNX_DFT* reps = aligned_alloc(64, (size + 63) & (UINT64_C(-64)));
+  if (reps == 0) FATAL_ERROR("Out of memory");
+  return reps;
+}
+
+EXPORT void spqlios_debug_free(void* addr) { free(addr - 64); }
+
+EXPORT void* spqlios_debug_alloc(uint64_t size) { return malloc(size + 64) + 64; }
 
 /** @brief sets res = 0 */
 EXPORT void vec_znx_zero(const MODULE* module,                             // N

--- a/spqlios/arithmetic/vec_znx.c
+++ b/spqlios/arithmetic/vec_znx.c
@@ -259,18 +259,6 @@ EXPORT uint64_t fft64_vec_znx_big_range_normalize_base2k_tmp_bytes(  //
     const MODULE* module                                             // N
     ) __attribute((alias("vec_znx_normalize_base2k_tmp_bytes_ref")));
 
-EXPORT void spqlios_free(void* addr) { free(addr); }
-
-EXPORT void* spqlios_alloc(uint64_t size) {
-  VEC_ZNX_DFT* reps = aligned_alloc(64, (size + 63) & (UINT64_C(-64)));
-  if (reps == 0) FATAL_ERROR("Out of memory");
-  return reps;
-}
-
-EXPORT void spqlios_debug_free(void* addr) { free(addr - 64); }
-
-EXPORT void* spqlios_debug_alloc(uint64_t size) { return malloc(size + 64) + 64; }
-
 /** @brief sets res = 0 */
 EXPORT void vec_znx_zero(const MODULE* module,                             // N
                          int64_t* res, uint64_t res_size, uint64_t res_sl  // res

--- a/spqlios/arithmetic/vec_znx_arithmetic.h
+++ b/spqlios/arithmetic/vec_znx_arithmetic.h
@@ -48,7 +48,7 @@ EXPORT uint64_t bytes_of_vec_znx_dft(const MODULE* module,  // N
 
 /** @brief allocates a vec_znx in DFT space */
 EXPORT VEC_ZNX_DFT* new_vec_znx_dft(const MODULE* module,  // N
-                                     uint64_t size);
+                                    uint64_t size);
 
 /** @brief frees memory from a vec_znx in DFT space */
 EXPORT void delete_vec_znx_dft(VEC_ZNX_DFT* res);
@@ -59,7 +59,7 @@ EXPORT uint64_t bytes_of_vec_znx_big(const MODULE* module,  // N
 
 /** @brief allocates a vec_znx_big */
 EXPORT VEC_ZNX_BIG* new_vec_znx_big(const MODULE* module,  // N
-                                             uint64_t size);
+                                    uint64_t size);
 /** @brief frees memory from a vec_znx_big */
 EXPORT void delete_vec_znx_big(VEC_ZNX_BIG* res);
 
@@ -78,7 +78,7 @@ EXPORT uint64_t bytes_of_vmp_pmat(const MODULE* module,  // N
 
 /** @brief allocates a prepared matrix */
 EXPORT VMP_PMAT* new_vmp_pmat(const MODULE* module,  // N
-                                       uint64_t nrows, uint64_t ncols);
+                              uint64_t nrows, uint64_t ncols);
 
 /** @brief frees memory for a prepared matrix */
 EXPORT void delete_vmp_pmat(VMP_PMAT* res);

--- a/spqlios/arithmetic/vec_znx_arithmetic.h
+++ b/spqlios/arithmetic/vec_znx_arithmetic.h
@@ -34,14 +34,6 @@ typedef struct cnv_pvec_l_t CNV_PVEC_L;
 /** @brief opaque type that represents a prepared right convolution vector product */
 typedef struct cnv_pvec_r_t CNV_PVEC_R;
 
-EXPORT void spqlios_free(void* address);
-
-EXPORT void* spqlios_alloc(uint64_t size);
-
-EXPORT void spqlios_debug_free(void* address);
-
-EXPORT void* spqlios_debug_alloc(uint64_t size);
-
 /** @brief bytes needed for a vec_znx in DFT space */
 EXPORT uint64_t bytes_of_vec_znx_dft(const MODULE* module,  // N
                                      uint64_t size);

--- a/spqlios/arithmetic/vec_znx_arithmetic.h
+++ b/spqlios/arithmetic/vec_znx_arithmetic.h
@@ -34,27 +34,54 @@ typedef struct cnv_pvec_l_t CNV_PVEC_L;
 /** @brief opaque type that represents a prepared right convolution vector product */
 typedef struct cnv_pvec_r_t CNV_PVEC_R;
 
-/** @brief allocates a prepared matrix (release with free) */
-EXPORT VMP_PMAT* vmp_pmat_alloc(const MODULE* module,           // N
-                                uint64_t nrows, uint64_t ncols  // dimensions
-);
+EXPORT void spqlios_free(void* address);
 
-/** @brief allocates a vec_znx in DFT space (release with free) */
-EXPORT VEC_ZNX_DFT* vec_znx_dft_alloc(const MODULE* module,  // N
-                                      uint64_t size);
+EXPORT void* spqlios_alloc(uint64_t size);
 
-/** @brief allocates a vec_znx_big (release with free) */
-EXPORT VEC_ZNX_BIG* vec_znx_big_alloc(const MODULE* module,  // N
-                                      uint64_t size);
+EXPORT void spqlios_debug_free(void* address);
 
-/** @brief allocates a prepared vector (release with free) */
-EXPORT SVP_PPOL* svp_ppol_alloc(const MODULE* module);  // N
+EXPORT void* spqlios_debug_alloc(uint64_t size);
 
-/** @brief free something (vec_znx, pvmp, pcnv...) was allocated
- * It just calls free. It is required to expose it for foreign
- * languages bindings that do cannot call libc directly
- */
-EXPORT void std_free(void* address);
+/** @brief bytes needed for a vec_znx in DFT space */
+EXPORT uint64_t bytes_of_vec_znx_dft(const MODULE* module,  // N
+                                     uint64_t size);
+
+/** @brief allocates a vec_znx in DFT space */
+EXPORT VEC_ZNX_DFT* new_vec_znx_dft(const MODULE* module,  // N
+                                     uint64_t size);
+
+/** @brief frees memory from a vec_znx in DFT space */
+EXPORT void delete_vec_znx_dft(VEC_ZNX_DFT* res);
+
+/** @brief bytes needed for a vec_znx_big */
+EXPORT uint64_t bytes_of_vec_znx_big(const MODULE* module,  // N
+                                     uint64_t size);
+
+/** @brief allocates a vec_znx_big */
+EXPORT VEC_ZNX_BIG* new_vec_znx_big(const MODULE* module,  // N
+                                             uint64_t size);
+/** @brief frees memory from a vec_znx_big */
+EXPORT void delete_vec_znx_big(VEC_ZNX_BIG* res);
+
+/** @brief bytes needed for a prepared vector */
+EXPORT uint64_t bytes_of_svp_ppol(const MODULE* module);  // N
+
+/** @brief allocates a prepared vector */
+EXPORT SVP_PPOL* new_svp_ppol(const MODULE* module);  // N
+
+/** @brief frees memory for a prepared vector */
+EXPORT void delete_svp_ppol(SVP_PPOL* res);
+
+/** @brief bytes needed for a prepared matrix */
+EXPORT uint64_t bytes_of_vmp_pmat(const MODULE* module,  // N
+                                  uint64_t nrows, uint64_t ncols);
+
+/** @brief allocates a prepared matrix */
+EXPORT VMP_PMAT* new_vmp_pmat(const MODULE* module,  // N
+                                       uint64_t nrows, uint64_t ncols);
+
+/** @brief frees memory for a prepared matrix */
+EXPORT void delete_vmp_pmat(VMP_PMAT* res);
 
 /**
  * @brief obtain a module info for ring dimension N

--- a/spqlios/arithmetic/vec_znx_arithmetic_private.h
+++ b/spqlios/arithmetic/vec_znx_arithmetic_private.h
@@ -149,9 +149,9 @@ struct module_virtual_functions_t {
   BYTES_OF_SVP_PPOL_F* bytes_of_svp_ppol;
   NEW_SVP_PPOL_F* new_svp_ppol;
   DELETE_SVP_PPOL_F* delete_svp_ppol;
-  BYTES_OF_VMP_PMAT_F * bytes_of_vmp_pmat;
-  NEW_VMP_PMAT_F * new_vmp_pmat;
-  DELETE_VMP_PMAT_F * delete_vmp_pmat;
+  BYTES_OF_VMP_PMAT_F* bytes_of_vmp_pmat;
+  NEW_VMP_PMAT_F* new_vmp_pmat;
+  DELETE_VMP_PMAT_F* delete_vmp_pmat;
 };
 
 union backend_module_info_t {
@@ -170,61 +170,55 @@ struct module_info_t {
   struct module_virtual_functions_t func;
 };
 
+#ifndef NDEBUG
+#define svp_ppol_spqlios_alloc(module) spqlios_debug_alloc(fft64_bytes_of_svp_ppol(module))
+#define svp_ppol_spqlios_free(ppol) spqlios_debug_free(ppol)
+#define vec_znx_big_spqlios_alloc(module, size) spqlios_debug_alloc(fft64_bytes_of_vec_znx_big(module, size))
+#define vec_znx_big_spqlios_free(res) spqlios_debug_free(res)
+#define vec_znx_dft_spqlios_alloc(module, size) spqlios_debug_alloc(fft64_bytes_of_vec_znx_dft(module, size))
+#define vec_znx_dft_spqlios_free(res) spqlios_debug_free(res)
+#define vmp_pmat_spqlios_alloc(module, nrows, ncols) spqlios_debug_alloc(fft64_bytes_of_vmp_pmat(module, nrows, ncols))
+#define vmp_pmat_spqlios_free(res) spqlios_debug_free(res)
+#else
+#define svp_ppol_spqlios_alloc(module) spqlios_alloc(fft64_bytes_of_svp_ppol(module))
+#define svp_ppol_spqlios_free(ppol) spqlios_free(ppol)
+#define vec_znx_big_spqlios_alloc(module, size) spqlios_alloc(fft64_bytes_of_vec_znx_big(module, size))
+#define vec_znx_big_spqlios_free(res) spqlios_free(res)
+#define vec_znx_dft_spqlios_alloc(module, size) spqlios_alloc(fft64_bytes_of_vec_znx_dft(module, size))
+#define vec_znx_dft_spqlios_free(res) spqlios_free(res)
+#define vmp_pmat_spqlios_alloc(module, nrows, ncols) spqlios_alloc(fft64_bytes_of_vmp_pmat(module, nrows, ncols))
+#define vmp_pmat_spqlios_free(res) spqlios_free(res)
+#endif
+
 EXPORT uint64_t fft64_bytes_of_vec_znx_dft(const MODULE* module,  // N
                                            uint64_t size);
 
 EXPORT VEC_ZNX_DFT* fft64_new_vec_znx_dft(const MODULE* module,  // N
-                                             uint64_t size);
+                                          uint64_t size);
 
 EXPORT void fft64_delete_vec_znx_dft(VEC_ZNX_DFT* res);
-
-/** @brief internal function that allocates a vec_znx in DFT space */
-EXPORT VEC_ZNX_DFT* vec_znx_dft_spqlios_alloc(const MODULE* module,  // N
-                                              uint64_t size);
-
-/** @brief internal function that frees memory from a vec_znx in DFT space */
-EXPORT void vec_znx_dft_spqlios_free(VEC_ZNX_DFT* res);
 
 EXPORT uint64_t fft64_bytes_of_vec_znx_big(const MODULE* module,  // N
                                            uint64_t size);
 
 EXPORT VEC_ZNX_BIG* fft64_new_vec_znx_big(const MODULE* module,  // N
-                                             uint64_t size);
+                                          uint64_t size);
 
 EXPORT void fft64_delete_vec_znx_big(VEC_ZNX_BIG* res);
 
-/** @brief internal function that allocates a vec_znx_big */
-EXPORT VEC_ZNX_BIG* vec_znx_big_spqlios_alloc(const MODULE* module,  // N
-                                              uint64_t size);
-/** @brief internal function that frees memory from a vec_znx_big */
-EXPORT void vec_znx_big_spqlios_free(VEC_ZNX_BIG* res);
+EXPORT uint64_t fft64_bytes_of_svp_ppol(const MODULE* module);  // N
 
-EXPORT uint64_t fft64_bytes_of_svp_ppol(const MODULE* module); // N
-
-EXPORT SVP_PPOL* fft64_new_svp_ppol(const MODULE* module); // N
+EXPORT SVP_PPOL* fft64_new_svp_ppol(const MODULE* module);  // N
 
 EXPORT void fft64_delete_svp_ppol(SVP_PPOL* res);
-
-/** @brief internal function that allocates a prepared vector */
-EXPORT SVP_PPOL* svp_ppol_spqlios_alloc(const MODULE* module);  // N
-
-/** @brief internal function that frees memory for a prepared vector */
-EXPORT void svp_ppol_spqlios_free(SVP_PPOL* res);
 
 EXPORT uint64_t fft64_bytes_of_vmp_pmat(const MODULE* module,  // N
                                         uint64_t nrows, uint64_t ncols);
 
 EXPORT VMP_PMAT* fft64_new_vmp_pmat(const MODULE* module,  // N
-                                       uint64_t nrows, uint64_t ncols);
+                                    uint64_t nrows, uint64_t ncols);
 
 EXPORT void fft64_delete_vmp_pmat(VMP_PMAT* res);
-
-/** @brief internal function that allocates a prepared matrix */
-EXPORT VMP_PMAT* vmp_pmat_spqlios_alloc(const MODULE* module,  // N
-                                        uint64_t nrows, uint64_t ncols);
-
-/** @brief internal function that frees memory for a prepared matrix */
-EXPORT void vmp_pmat_spqlios_free(VMP_PMAT* res);
 
 EXPORT void vec_znx_zero_ref(const MODULE* module,                             // N
                              int64_t* res, uint64_t res_size, uint64_t res_sl  // res

--- a/spqlios/arithmetic/vec_znx_arithmetic_private.h
+++ b/spqlios/arithmetic/vec_znx_arithmetic_private.h
@@ -90,17 +90,9 @@ typedef typeof(vmp_apply_dft_tmp_bytes) VMP_APPLY_DFT_TMP_BYTES_F;
 typedef typeof(vmp_apply_dft_to_dft) VMP_APPLY_DFT_TO_DFT_F;
 typedef typeof(vmp_apply_dft_to_dft_tmp_bytes) VMP_APPLY_DFT_TO_DFT_TMP_BYTES_F;
 typedef typeof(bytes_of_vec_znx_dft) BYTES_OF_VEC_ZNX_DFT_F;
-typedef typeof(new_vec_znx_dft) NEW_VEC_ZNX_DFT_F;
-typedef typeof(delete_vec_znx_dft) DELETE_VEC_ZNX_DFT_F;
 typedef typeof(bytes_of_vec_znx_big) BYTES_OF_VEC_ZNX_BIG_F;
-typedef typeof(new_vec_znx_big) NEW_VEC_ZNX_BIG_F;
-typedef typeof(delete_vec_znx_big) DELETE_VEC_ZNX_BIG_F;
 typedef typeof(bytes_of_svp_ppol) BYTES_OF_SVP_PPOL_F;
-typedef typeof(new_svp_ppol) NEW_SVP_PPOL_F;
-typedef typeof(delete_svp_ppol) DELETE_SVP_PPOL_F;
 typedef typeof(bytes_of_vmp_pmat) BYTES_OF_VMP_PMAT_F;
-typedef typeof(new_vmp_pmat) NEW_VMP_PMAT_F;
-typedef typeof(delete_vmp_pmat) DELETE_VMP_PMAT_F;
 
 struct module_virtual_functions_t {
   // TODO add functions here
@@ -141,17 +133,9 @@ struct module_virtual_functions_t {
   VMP_APPLY_DFT_TO_DFT_F* vmp_apply_dft_to_dft;
   VMP_APPLY_DFT_TO_DFT_TMP_BYTES_F* vmp_apply_dft_to_dft_tmp_bytes;
   BYTES_OF_VEC_ZNX_DFT_F* bytes_of_vec_znx_dft;
-  NEW_VEC_ZNX_DFT_F* new_vec_znx_dft;
-  DELETE_VEC_ZNX_DFT_F* delete_vec_znx_dft;
   BYTES_OF_VEC_ZNX_BIG_F* bytes_of_vec_znx_big;
-  NEW_VEC_ZNX_BIG_F* new_vec_znx_big;
-  DELETE_VEC_ZNX_BIG_F* delete_vec_znx_big;
   BYTES_OF_SVP_PPOL_F* bytes_of_svp_ppol;
-  NEW_SVP_PPOL_F* new_svp_ppol;
-  DELETE_SVP_PPOL_F* delete_svp_ppol;
   BYTES_OF_VMP_PMAT_F* bytes_of_vmp_pmat;
-  NEW_VMP_PMAT_F* new_vmp_pmat;
-  DELETE_VMP_PMAT_F* delete_vmp_pmat;
 };
 
 union backend_module_info_t {
@@ -169,26 +153,6 @@ struct module_info_t {
   // virtual functions
   struct module_virtual_functions_t func;
 };
-
-#ifndef NDEBUG
-#define svp_ppol_spqlios_alloc(module) spqlios_debug_alloc(fft64_bytes_of_svp_ppol(module))
-#define svp_ppol_spqlios_free(ppol) spqlios_debug_free(ppol)
-#define vec_znx_big_spqlios_alloc(module, size) spqlios_debug_alloc(fft64_bytes_of_vec_znx_big(module, size))
-#define vec_znx_big_spqlios_free(res) spqlios_debug_free(res)
-#define vec_znx_dft_spqlios_alloc(module, size) spqlios_debug_alloc(fft64_bytes_of_vec_znx_dft(module, size))
-#define vec_znx_dft_spqlios_free(res) spqlios_debug_free(res)
-#define vmp_pmat_spqlios_alloc(module, nrows, ncols) spqlios_debug_alloc(fft64_bytes_of_vmp_pmat(module, nrows, ncols))
-#define vmp_pmat_spqlios_free(res) spqlios_debug_free(res)
-#else
-#define svp_ppol_spqlios_alloc(module) spqlios_alloc(fft64_bytes_of_svp_ppol(module))
-#define svp_ppol_spqlios_free(ppol) spqlios_free(ppol)
-#define vec_znx_big_spqlios_alloc(module, size) spqlios_alloc(fft64_bytes_of_vec_znx_big(module, size))
-#define vec_znx_big_spqlios_free(res) spqlios_free(res)
-#define vec_znx_dft_spqlios_alloc(module, size) spqlios_alloc(fft64_bytes_of_vec_znx_dft(module, size))
-#define vec_znx_dft_spqlios_free(res) spqlios_free(res)
-#define vmp_pmat_spqlios_alloc(module, nrows, ncols) spqlios_alloc(fft64_bytes_of_vmp_pmat(module, nrows, ncols))
-#define vmp_pmat_spqlios_free(res) spqlios_free(res)
-#endif
 
 EXPORT uint64_t fft64_bytes_of_vec_znx_dft(const MODULE* module,  // N
                                            uint64_t size);

--- a/spqlios/arithmetic/vec_znx_arithmetic_private.h
+++ b/spqlios/arithmetic/vec_znx_arithmetic_private.h
@@ -53,10 +53,6 @@ struct q120_module_info_t {
 };
 
 // TODO add function types here
-typedef typeof(vmp_pmat_alloc) VMP_PMAT_ALLOC_F;
-typedef typeof(vec_znx_dft_alloc) VEC_ZNX_DFT_ALLOC_F;
-typedef typeof(vec_znx_big_alloc) VEC_ZNX_BIG_ALLOC_F;
-typedef typeof(svp_ppol_alloc) SVP_PPOL_ALLOC_F;
 typedef typeof(vec_znx_zero) VEC_ZNX_ZERO_F;
 typedef typeof(vec_znx_copy) VEC_ZNX_COPY_F;
 typedef typeof(vec_znx_negate) VEC_ZNX_NEGATE_F;
@@ -93,13 +89,21 @@ typedef typeof(vmp_apply_dft) VMP_APPLY_DFT_F;
 typedef typeof(vmp_apply_dft_tmp_bytes) VMP_APPLY_DFT_TMP_BYTES_F;
 typedef typeof(vmp_apply_dft_to_dft) VMP_APPLY_DFT_TO_DFT_F;
 typedef typeof(vmp_apply_dft_to_dft_tmp_bytes) VMP_APPLY_DFT_TO_DFT_TMP_BYTES_F;
+typedef typeof(bytes_of_vec_znx_dft) BYTES_OF_VEC_ZNX_DFT_F;
+typedef typeof(new_vec_znx_dft) NEW_VEC_ZNX_DFT_F;
+typedef typeof(delete_vec_znx_dft) DELETE_VEC_ZNX_DFT_F;
+typedef typeof(bytes_of_vec_znx_big) BYTES_OF_VEC_ZNX_BIG_F;
+typedef typeof(new_vec_znx_big) NEW_VEC_ZNX_BIG_F;
+typedef typeof(delete_vec_znx_big) DELETE_VEC_ZNX_BIG_F;
+typedef typeof(bytes_of_svp_ppol) BYTES_OF_SVP_PPOL_F;
+typedef typeof(new_svp_ppol) NEW_SVP_PPOL_F;
+typedef typeof(delete_svp_ppol) DELETE_SVP_PPOL_F;
+typedef typeof(bytes_of_vmp_pmat) BYTES_OF_VMP_PMAT_F;
+typedef typeof(new_vmp_pmat) NEW_VMP_PMAT_F;
+typedef typeof(delete_vmp_pmat) DELETE_VMP_PMAT_F;
 
 struct module_virtual_functions_t {
   // TODO add functions here
-  VMP_PMAT_ALLOC_F* vmp_pmat_alloc;
-  VEC_ZNX_DFT_ALLOC_F* vec_znx_dft_alloc;
-  VEC_ZNX_BIG_ALLOC_F* vec_znx_big_alloc;
-  SVP_PPOL_ALLOC_F* svp_ppol_alloc;
   VEC_ZNX_ZERO_F* vec_znx_zero;
   VEC_ZNX_COPY_F* vec_znx_copy;
   VEC_ZNX_NEGATE_F* vec_znx_negate;
@@ -136,6 +140,18 @@ struct module_virtual_functions_t {
   VMP_APPLY_DFT_TMP_BYTES_F* vmp_apply_dft_tmp_bytes;
   VMP_APPLY_DFT_TO_DFT_F* vmp_apply_dft_to_dft;
   VMP_APPLY_DFT_TO_DFT_TMP_BYTES_F* vmp_apply_dft_to_dft_tmp_bytes;
+  BYTES_OF_VEC_ZNX_DFT_F* bytes_of_vec_znx_dft;
+  NEW_VEC_ZNX_DFT_F* new_vec_znx_dft;
+  DELETE_VEC_ZNX_DFT_F* delete_vec_znx_dft;
+  BYTES_OF_VEC_ZNX_BIG_F* bytes_of_vec_znx_big;
+  NEW_VEC_ZNX_BIG_F* new_vec_znx_big;
+  DELETE_VEC_ZNX_BIG_F* delete_vec_znx_big;
+  BYTES_OF_SVP_PPOL_F* bytes_of_svp_ppol;
+  NEW_SVP_PPOL_F* new_svp_ppol;
+  DELETE_SVP_PPOL_F* delete_svp_ppol;
+  BYTES_OF_VMP_PMAT_F * bytes_of_vmp_pmat;
+  NEW_VMP_PMAT_F * new_vmp_pmat;
+  DELETE_VMP_PMAT_F * delete_vmp_pmat;
 };
 
 union backend_module_info_t {
@@ -154,17 +170,61 @@ struct module_info_t {
   struct module_virtual_functions_t func;
 };
 
-EXPORT VMP_PMAT* fft64_vmp_pmat_alloc(const MODULE* module,           // N
-                                      uint64_t nrows, uint64_t ncols  // dimensions
-);
+EXPORT uint64_t fft64_bytes_of_vec_znx_dft(const MODULE* module,  // N
+                                           uint64_t size);
 
-EXPORT VEC_ZNX_DFT* fft64_vec_znx_dft_alloc(const MODULE* module,  // N
-                                            uint64_t size);
+EXPORT VEC_ZNX_DFT* fft64_new_vec_znx_dft(const MODULE* module,  // N
+                                             uint64_t size);
 
-EXPORT VEC_ZNX_BIG* fft64_vec_znx_big_alloc(const MODULE* module,  // N
-                                            uint64_t size);
+EXPORT void fft64_delete_vec_znx_dft(VEC_ZNX_DFT* res);
 
-EXPORT SVP_PPOL* fft64_svp_ppol_alloc(const MODULE* module);  // N
+/** @brief internal function that allocates a vec_znx in DFT space */
+EXPORT VEC_ZNX_DFT* vec_znx_dft_spqlios_alloc(const MODULE* module,  // N
+                                              uint64_t size);
+
+/** @brief internal function that frees memory from a vec_znx in DFT space */
+EXPORT void vec_znx_dft_spqlios_free(VEC_ZNX_DFT* res);
+
+EXPORT uint64_t fft64_bytes_of_vec_znx_big(const MODULE* module,  // N
+                                           uint64_t size);
+
+EXPORT VEC_ZNX_BIG* fft64_new_vec_znx_big(const MODULE* module,  // N
+                                             uint64_t size);
+
+EXPORT void fft64_delete_vec_znx_big(VEC_ZNX_BIG* res);
+
+/** @brief internal function that allocates a vec_znx_big */
+EXPORT VEC_ZNX_BIG* vec_znx_big_spqlios_alloc(const MODULE* module,  // N
+                                              uint64_t size);
+/** @brief internal function that frees memory from a vec_znx_big */
+EXPORT void vec_znx_big_spqlios_free(VEC_ZNX_BIG* res);
+
+EXPORT uint64_t fft64_bytes_of_svp_ppol(const MODULE* module); // N
+
+EXPORT SVP_PPOL* fft64_new_svp_ppol(const MODULE* module); // N
+
+EXPORT void fft64_delete_svp_ppol(SVP_PPOL* res);
+
+/** @brief internal function that allocates a prepared vector */
+EXPORT SVP_PPOL* svp_ppol_spqlios_alloc(const MODULE* module);  // N
+
+/** @brief internal function that frees memory for a prepared vector */
+EXPORT void svp_ppol_spqlios_free(SVP_PPOL* res);
+
+EXPORT uint64_t fft64_bytes_of_vmp_pmat(const MODULE* module,  // N
+                                        uint64_t nrows, uint64_t ncols);
+
+EXPORT VMP_PMAT* fft64_new_vmp_pmat(const MODULE* module,  // N
+                                       uint64_t nrows, uint64_t ncols);
+
+EXPORT void fft64_delete_vmp_pmat(VMP_PMAT* res);
+
+/** @brief internal function that allocates a prepared matrix */
+EXPORT VMP_PMAT* vmp_pmat_spqlios_alloc(const MODULE* module,  // N
+                                        uint64_t nrows, uint64_t ncols);
+
+/** @brief internal function that frees memory for a prepared matrix */
+EXPORT void vmp_pmat_spqlios_free(VMP_PMAT* res);
 
 EXPORT void vec_znx_zero_ref(const MODULE* module,                             // N
                              int64_t* res, uint64_t res_size, uint64_t res_sl  // res

--- a/spqlios/arithmetic/vec_znx_big.c
+++ b/spqlios/arithmetic/vec_znx_big.c
@@ -1,18 +1,16 @@
 #include "vec_znx_arithmetic_private.h"
 
 EXPORT uint64_t bytes_of_vec_znx_big(const MODULE* module,  // N
-                                      uint64_t size) {
+                                     uint64_t size) {
   return module->func.bytes_of_vec_znx_big(module, size);
 }
 
 EXPORT VEC_ZNX_BIG* new_vec_znx_big(const MODULE* module,  // N
-                                             uint64_t size) {
+                                    uint64_t size) {
   return module->func.new_vec_znx_big(module, size);
 }
 
-EXPORT void delete_vec_znx_big(VEC_ZNX_BIG* res) {
-  spqlios_free(res);
-}
+EXPORT void delete_vec_znx_big(VEC_ZNX_BIG* res) { spqlios_free(res); }
 
 // public wrappers
 
@@ -100,30 +98,11 @@ EXPORT uint64_t fft64_bytes_of_vec_znx_big(const MODULE* module,  // N
 }
 
 EXPORT VEC_ZNX_BIG* fft64_new_vec_znx_big(const MODULE* module,  // N
-                                                   uint64_t size) {
+                                          uint64_t size) {
   return spqlios_alloc(fft64_bytes_of_vec_znx_big(module, size));
 }
 
-EXPORT void fft64_delete_vec_znx_big(VEC_ZNX_BIG* res) {
-  spqlios_free(res);
-}
-
-EXPORT VEC_ZNX_BIG* vec_znx_big_spqlios_alloc(const MODULE* module,  // N
-uint64_t size) {
-#ifndef NDEBUG
-  return spqlios_debug_alloc(fft64_bytes_of_vec_znx_big(module, size));
-#else
-  return spqlios_alloc(fft64_bytes_of_vec_znx_big(module, size));
-#endif
-}
-
-EXPORT void vec_znx_big_spqlios_free(VEC_ZNX_BIG* res) {
-#ifndef NDEBUG
-  spqlios_debug_free(res);
-#else
-  spqlios_free(res);
-#endif
-}
+EXPORT void fft64_delete_vec_znx_big(VEC_ZNX_BIG* res) { spqlios_free(res); }
 
 /** @brief sets res = a+b */
 EXPORT void fft64_vec_znx_big_add(const MODULE* module,                   // N

--- a/spqlios/arithmetic/vec_znx_big.c
+++ b/spqlios/arithmetic/vec_znx_big.c
@@ -5,13 +5,6 @@ EXPORT uint64_t bytes_of_vec_znx_big(const MODULE* module,  // N
   return module->func.bytes_of_vec_znx_big(module, size);
 }
 
-EXPORT VEC_ZNX_BIG* new_vec_znx_big(const MODULE* module,  // N
-                                    uint64_t size) {
-  return module->func.new_vec_znx_big(module, size);
-}
-
-EXPORT void delete_vec_znx_big(VEC_ZNX_BIG* res) { spqlios_free(res); }
-
 // public wrappers
 
 /** @brief sets res = a+b */

--- a/spqlios/arithmetic/vec_znx_big.c
+++ b/spqlios/arithmetic/vec_znx_big.c
@@ -1,8 +1,17 @@
 #include "vec_znx_arithmetic_private.h"
 
-EXPORT VEC_ZNX_BIG* vec_znx_big_alloc(const MODULE* module,  // N
+EXPORT uint64_t bytes_of_vec_znx_big(const MODULE* module,  // N
                                       uint64_t size) {
-  return module->func.vec_znx_big_alloc(module, size);
+  return module->func.bytes_of_vec_znx_big(module, size);
+}
+
+EXPORT VEC_ZNX_BIG* new_vec_znx_big(const MODULE* module,  // N
+                                             uint64_t size) {
+  return module->func.new_vec_znx_big(module, size);
+}
+
+EXPORT void delete_vec_znx_big(VEC_ZNX_BIG* res) {
+  spqlios_free(res);
 }
 
 // public wrappers
@@ -85,12 +94,35 @@ EXPORT void vec_znx_big_automorphism(const MODULE* module,                  // N
 
 // private wrappers
 
-EXPORT VEC_ZNX_BIG* fft64_vec_znx_big_alloc(const MODULE* module,  // N
-                                            uint64_t size) {
-  const uint64_t rsize = module->nn * size * sizeof(double);
-  VEC_ZNX_BIG* reps = aligned_alloc(64, (rsize + 63) & (UINT64_C(-64)));
-  if (reps == 0) FATAL_ERROR("Out of memory");
-  return reps;
+EXPORT uint64_t fft64_bytes_of_vec_znx_big(const MODULE* module,  // N
+                                           uint64_t size) {
+  return module->nn * size * sizeof(double);
+}
+
+EXPORT VEC_ZNX_BIG* fft64_new_vec_znx_big(const MODULE* module,  // N
+                                                   uint64_t size) {
+  return spqlios_alloc(fft64_bytes_of_vec_znx_big(module, size));
+}
+
+EXPORT void fft64_delete_vec_znx_big(VEC_ZNX_BIG* res) {
+  spqlios_free(res);
+}
+
+EXPORT VEC_ZNX_BIG* vec_znx_big_spqlios_alloc(const MODULE* module,  // N
+uint64_t size) {
+#ifndef NDEBUG
+  return spqlios_debug_alloc(fft64_bytes_of_vec_znx_big(module, size));
+#else
+  return spqlios_alloc(fft64_bytes_of_vec_znx_big(module, size));
+#endif
+}
+
+EXPORT void vec_znx_big_spqlios_free(VEC_ZNX_BIG* res) {
+#ifndef NDEBUG
+  spqlios_debug_free(res);
+#else
+  spqlios_free(res);
+#endif
 }
 
 /** @brief sets res = a+b */

--- a/spqlios/arithmetic/vec_znx_dft.c
+++ b/spqlios/arithmetic/vec_znx_dft.c
@@ -32,13 +32,6 @@ EXPORT uint64_t bytes_of_vec_znx_dft(const MODULE* module,  // N
   return module->func.bytes_of_vec_znx_dft(module, size);
 }
 
-EXPORT VEC_ZNX_DFT* new_vec_znx_dft(const MODULE* module,  // N
-                                    uint64_t size) {
-  return module->func.new_vec_znx_dft(module, size);
-}
-
-EXPORT void delete_vec_znx_dft(VEC_ZNX_DFT* res) { spqlios_free(res); }
-
 // fft64 backend
 EXPORT uint64_t fft64_bytes_of_vec_znx_dft(const MODULE* module,  // N
                                            uint64_t size) {

--- a/spqlios/arithmetic/vec_znx_dft.c
+++ b/spqlios/arithmetic/vec_znx_dft.c
@@ -28,50 +28,29 @@ EXPORT void vec_znx_idft_tmp_a(const MODULE* module,                 // N
 }
 
 EXPORT uint64_t bytes_of_vec_znx_dft(const MODULE* module,  // N
-                                         uint64_t size) {
+                                     uint64_t size) {
   return module->func.bytes_of_vec_znx_dft(module, size);
 }
 
 EXPORT VEC_ZNX_DFT* new_vec_znx_dft(const MODULE* module,  // N
-                                             uint64_t size) {
+                                    uint64_t size) {
   return module->func.new_vec_znx_dft(module, size);
 }
 
-EXPORT void delete_vec_znx_dft(VEC_ZNX_DFT* res) {
-  spqlios_free(res);
-}
+EXPORT void delete_vec_znx_dft(VEC_ZNX_DFT* res) { spqlios_free(res); }
 
 // fft64 backend
 EXPORT uint64_t fft64_bytes_of_vec_znx_dft(const MODULE* module,  // N
-                                            uint64_t size) {
+                                           uint64_t size) {
   return module->nn * size * sizeof(double);
 }
 
 EXPORT VEC_ZNX_DFT* fft64_new_vec_znx_dft(const MODULE* module,  // N
-                                                   uint64_t size) {
+                                          uint64_t size) {
   return spqlios_alloc(fft64_bytes_of_vec_znx_dft(module, size));
 }
 
-EXPORT void fft64_delete_vec_znx_dft(VEC_ZNX_DFT* res) {
-  spqlios_free(res);
-}
-
-EXPORT VEC_ZNX_DFT* vec_znx_dft_spqlios_alloc(const MODULE* module,  // N
-                                              uint64_t size) {
-#ifndef NDEBUG
-  return spqlios_debug_alloc(fft64_bytes_of_vec_znx_dft(module, size));
-#else
-  return spqlios_alloc(fft64_bytes_of_vec_znx_dft(module, size));
-#endif
-}
-
-EXPORT void vec_znx_dft_spqlios_free(VEC_ZNX_DFT* res) {
-#ifndef NDEBUG
-  spqlios_debug_free(res);
-#else
-  spqlios_free(res);
-#endif
-}
+EXPORT void fft64_delete_vec_znx_dft(VEC_ZNX_DFT* res) { spqlios_free(res); }
 
 EXPORT void fft64_vec_znx_dft(const MODULE* module,                             // N
                               VEC_ZNX_DFT* res, uint64_t res_size,              // res

--- a/spqlios/arithmetic/vec_znx_dft.c
+++ b/spqlios/arithmetic/vec_znx_dft.c
@@ -27,19 +27,50 @@ EXPORT void vec_znx_idft_tmp_a(const MODULE* module,                 // N
   return module->func.vec_znx_idft_tmp_a(module, res, res_size, a_dft, a_size);
 }
 
-EXPORT VEC_ZNX_DFT* vec_znx_dft_alloc(const MODULE* module,  // N
-                                      uint64_t size) {
-  return module->func.vec_znx_dft_alloc(module, size);
+EXPORT uint64_t bytes_of_vec_znx_dft(const MODULE* module,  // N
+                                         uint64_t size) {
+  return module->func.bytes_of_vec_znx_dft(module, size);
+}
+
+EXPORT VEC_ZNX_DFT* new_vec_znx_dft(const MODULE* module,  // N
+                                             uint64_t size) {
+  return module->func.new_vec_znx_dft(module, size);
+}
+
+EXPORT void delete_vec_znx_dft(VEC_ZNX_DFT* res) {
+  spqlios_free(res);
 }
 
 // fft64 backend
-
-EXPORT VEC_ZNX_DFT* fft64_vec_znx_dft_alloc(const MODULE* module,  // N
+EXPORT uint64_t fft64_bytes_of_vec_znx_dft(const MODULE* module,  // N
                                             uint64_t size) {
-  const uint64_t rsize = module->nn * size * sizeof(double);
-  VEC_ZNX_DFT* reps = aligned_alloc(64, (rsize + 63) & (UINT64_C(-64)));
-  if (reps == 0) FATAL_ERROR("Out of memory");
-  return reps;
+  return module->nn * size * sizeof(double);
+}
+
+EXPORT VEC_ZNX_DFT* fft64_new_vec_znx_dft(const MODULE* module,  // N
+                                                   uint64_t size) {
+  return spqlios_alloc(fft64_bytes_of_vec_znx_dft(module, size));
+}
+
+EXPORT void fft64_delete_vec_znx_dft(VEC_ZNX_DFT* res) {
+  spqlios_free(res);
+}
+
+EXPORT VEC_ZNX_DFT* vec_znx_dft_spqlios_alloc(const MODULE* module,  // N
+                                              uint64_t size) {
+#ifndef NDEBUG
+  return spqlios_debug_alloc(fft64_bytes_of_vec_znx_dft(module, size));
+#else
+  return spqlios_alloc(fft64_bytes_of_vec_znx_dft(module, size));
+#endif
+}
+
+EXPORT void vec_znx_dft_spqlios_free(VEC_ZNX_DFT* res) {
+#ifndef NDEBUG
+  spqlios_debug_free(res);
+#else
+  spqlios_free(res);
+#endif
 }
 
 EXPORT void fft64_vec_znx_dft(const MODULE* module,                             // N

--- a/spqlios/arithmetic/vector_matrix_product.c
+++ b/spqlios/arithmetic/vector_matrix_product.c
@@ -4,55 +4,33 @@
 #include "vec_znx_arithmetic_private.h"
 
 EXPORT uint64_t bytes_of_vmp_pmat(const MODULE* module,           // N
-                                uint64_t nrows, uint64_t ncols  // dimensions
+                                  uint64_t nrows, uint64_t ncols  // dimensions
 ) {
   return module->func.bytes_of_vmp_pmat(module, nrows, ncols);
 }
 
-EXPORT VMP_PMAT* new_vmp_pmat(const MODULE* module,  // N
-                                             uint64_t nrows, uint64_t ncols  // dimensions
+EXPORT VMP_PMAT* new_vmp_pmat(const MODULE* module,           // N
+                              uint64_t nrows, uint64_t ncols  // dimensions
 ) {
   return module->func.new_vmp_pmat(module, nrows, ncols);
 }
 
-EXPORT void delete_vmp_pmat(VMP_PMAT* res) {
-  spqlios_free(res);
-}
+EXPORT void delete_vmp_pmat(VMP_PMAT* res) { spqlios_free(res); }
 
 // fft64
 EXPORT uint64_t fft64_bytes_of_vmp_pmat(const MODULE* module,           // N
-                                      uint64_t nrows, uint64_t ncols  // dimensions
+                                        uint64_t nrows, uint64_t ncols  // dimensions
 ) {
   return module->nn * nrows * ncols * sizeof(double);
 }
 
-EXPORT VMP_PMAT* fft64_new_vmp_pmat(const MODULE* module,  // N
-                                                   uint64_t nrows, uint64_t ncols  // dimensions
+EXPORT VMP_PMAT* fft64_new_vmp_pmat(const MODULE* module,           // N
+                                    uint64_t nrows, uint64_t ncols  // dimensions
 ) {
   return spqlios_alloc(fft64_bytes_of_vmp_pmat(module, nrows, ncols));
 }
 
-EXPORT void fft64_delete_vmp_pmat(VMP_PMAT* res) {
-  spqlios_free(res);
-}
-
-EXPORT VMP_PMAT* vmp_pmat_spqlios_alloc(const MODULE* module,  // N
-                                        uint64_t nrows, uint64_t ncols  // dimensions
-) {
-#ifndef NDEBUG
-  return spqlios_debug_alloc(fft64_bytes_of_vmp_pmat(module, nrows, ncols));
-#else
-  return spqlios_alloc(fft64_bytes_of_vmp_pmat(module, nrows, ncols));
-#endif
-}
-
-EXPORT void vmp_pmat_spqlios_free(VMP_PMAT* res) {
-#ifndef NDEBUG
-  spqlios_debug_free(res);
-#else
-  spqlios_free(res);
-#endif
-}
+EXPORT void fft64_delete_vmp_pmat(VMP_PMAT* res) { spqlios_free(res); }
 
 /** @brief prepares a vmp matrix (contiguous row-major version) */
 EXPORT void vmp_prepare_contiguous(const MODULE* module,                                // N

--- a/spqlios/arithmetic/vector_matrix_product.c
+++ b/spqlios/arithmetic/vector_matrix_product.c
@@ -3,21 +3,55 @@
 #include "../reim4/reim4_arithmetic.h"
 #include "vec_znx_arithmetic_private.h"
 
-EXPORT VMP_PMAT* vmp_pmat_alloc(const MODULE* module,           // N
+EXPORT uint64_t bytes_of_vmp_pmat(const MODULE* module,           // N
                                 uint64_t nrows, uint64_t ncols  // dimensions
 ) {
-  return module->func.vmp_pmat_alloc(module, nrows, ncols);
+  return module->func.bytes_of_vmp_pmat(module, nrows, ncols);
+}
+
+EXPORT VMP_PMAT* new_vmp_pmat(const MODULE* module,  // N
+                                             uint64_t nrows, uint64_t ncols  // dimensions
+) {
+  return module->func.new_vmp_pmat(module, nrows, ncols);
+}
+
+EXPORT void delete_vmp_pmat(VMP_PMAT* res) {
+  spqlios_free(res);
 }
 
 // fft64
-
-EXPORT VMP_PMAT* fft64_vmp_pmat_alloc(const MODULE* module,           // N
+EXPORT uint64_t fft64_bytes_of_vmp_pmat(const MODULE* module,           // N
                                       uint64_t nrows, uint64_t ncols  // dimensions
 ) {
-  const uint64_t rsize = module->nn * nrows * ncols * sizeof(double);
-  VMP_PMAT* reps = aligned_alloc(64, (rsize + 63) & (UINT64_C(-64)));
-  if (reps == 0) FATAL_ERROR("Out of memory");
-  return reps;
+  return module->nn * nrows * ncols * sizeof(double);
+}
+
+EXPORT VMP_PMAT* fft64_new_vmp_pmat(const MODULE* module,  // N
+                                                   uint64_t nrows, uint64_t ncols  // dimensions
+) {
+  return spqlios_alloc(fft64_bytes_of_vmp_pmat(module, nrows, ncols));
+}
+
+EXPORT void fft64_delete_vmp_pmat(VMP_PMAT* res) {
+  spqlios_free(res);
+}
+
+EXPORT VMP_PMAT* vmp_pmat_spqlios_alloc(const MODULE* module,  // N
+                                        uint64_t nrows, uint64_t ncols  // dimensions
+) {
+#ifndef NDEBUG
+  return spqlios_debug_alloc(fft64_bytes_of_vmp_pmat(module, nrows, ncols));
+#else
+  return spqlios_alloc(fft64_bytes_of_vmp_pmat(module, nrows, ncols));
+#endif
+}
+
+EXPORT void vmp_pmat_spqlios_free(VMP_PMAT* res) {
+#ifndef NDEBUG
+  spqlios_debug_free(res);
+#else
+  spqlios_free(res);
+#endif
 }
 
 /** @brief prepares a vmp matrix (contiguous row-major version) */

--- a/spqlios/arithmetic/vector_matrix_product.c
+++ b/spqlios/arithmetic/vector_matrix_product.c
@@ -9,14 +9,6 @@ EXPORT uint64_t bytes_of_vmp_pmat(const MODULE* module,           // N
   return module->func.bytes_of_vmp_pmat(module, nrows, ncols);
 }
 
-EXPORT VMP_PMAT* new_vmp_pmat(const MODULE* module,           // N
-                              uint64_t nrows, uint64_t ncols  // dimensions
-) {
-  return module->func.new_vmp_pmat(module, nrows, ncols);
-}
-
-EXPORT void delete_vmp_pmat(VMP_PMAT* res) { spqlios_free(res); }
-
 // fft64
 EXPORT uint64_t fft64_bytes_of_vmp_pmat(const MODULE* module,           // N
                                         uint64_t nrows, uint64_t ncols  // dimensions

--- a/spqlios/commons.c
+++ b/spqlios/commons.c
@@ -21,10 +21,6 @@ EXPORT void NOT_IMPLEMENTED_v_uvpcvpcvp(uint32_t n, void* r, const void* a, cons
 EXPORT void NOT_IMPLEMENTED_v_uvpvpcvp(uint32_t n, void* a, void* b, const void* o) { NOT_IMPLEMENTED(); }
 
 #ifdef _WIN32
-EXPORT void* aligned_alloc(size_t align, size_t n) {
-  return malloc(n);
-  // unfortunately, there is no alternative that gets freed with free :(
-}
 #define __always_inline inline __attribute((always_inline))
 #endif
 
@@ -114,4 +110,36 @@ double internal_accurate_sin(double x) {
   double rcos, rsin;
   internal_accurate_sincos(&rcos, &rsin, x);
   return rsin;
+}
+
+EXPORT void spqlios_debug_free(void* addr) { free(addr - 64); }
+
+EXPORT void* spqlios_debug_alloc(uint64_t size) { return malloc(size + 64) + 64; }
+
+EXPORT void spqlios_free(void* addr) {
+#ifdef _WIN32
+  _aligned_free(addr);
+#else
+  free(addr);
+#endif
+}
+
+EXPORT void* spqlios_alloc(uint64_t size) {
+#ifdef _WIN32
+  void* reps = _aligned_malloc((size + 63) & (UINT64_C(-64)), 64);
+#else
+  void* reps = aligned_alloc(64, (size + 63) & (UINT64_C(-64)));
+#endif
+  if (reps == 0) FATAL_ERROR("Out of memory");
+  return reps;
+}
+
+EXPORT void* spqlios_alloc_custom_align(uint64_t align, uint64_t size) {
+#ifdef _WIN32
+  void* reps = _aligned_malloc(size, align);
+#else
+  void* reps = aligned_alloc(align, size);
+#endif
+  if (reps == 0) FATAL_ERROR("Out of memory");
+  return reps;
 }

--- a/spqlios/commons.h
+++ b/spqlios/commons.h
@@ -49,12 +49,34 @@ EXPORT void NOT_IMPLEMENTED_v_uvpcvpcvp(uint32_t n, void* r, const void* a, cons
 EXPORT void NOT_IMPLEMENTED_v_uvpvpcvp(uint32_t n, void* a, void* b, const void* o);
 
 // windows
+
 #ifdef _WIN32
-EXPORT void* aligned_alloc(size_t align, size_t n);
-#ifdef __cplusplus
-#define aligned_alloc ::aligned_alloc
-#endif
 #define __always_inline inline __attribute((always_inline))
+#endif
+
+EXPORT void spqlios_free(void* address);
+
+EXPORT void* spqlios_alloc(uint64_t size);
+EXPORT void* spqlios_alloc_custom_align(uint64_t align, uint64_t size);
+
+#ifndef NDEBUG
+#define svp_ppol_spqlios_alloc(module) spqlios_debug_alloc(fft64_bytes_of_svp_ppol(module))
+#define svp_ppol_spqlios_free(ppol) spqlios_debug_free(ppol)
+#define vec_znx_big_spqlios_alloc(module, size) spqlios_debug_alloc(fft64_bytes_of_vec_znx_big(module, size))
+#define vec_znx_big_spqlios_free(res) spqlios_debug_free(res)
+#define vec_znx_dft_spqlios_alloc(module, size) spqlios_debug_alloc(fft64_bytes_of_vec_znx_dft(module, size))
+#define vec_znx_dft_spqlios_free(res) spqlios_debug_free(res)
+#define vmp_pmat_spqlios_alloc(module, nrows, ncols) spqlios_debug_alloc(fft64_bytes_of_vmp_pmat(module, nrows, ncols))
+#define vmp_pmat_spqlios_free(res) spqlios_debug_free(res)
+#else
+#define svp_ppol_spqlios_alloc(module) spqlios_alloc(fft64_bytes_of_svp_ppol(module))
+#define svp_ppol_spqlios_free(ppol) spqlios_free(ppol)
+#define vec_znx_big_spqlios_alloc(module, size) spqlios_alloc(fft64_bytes_of_vec_znx_big(module, size))
+#define vec_znx_big_spqlios_free(res) spqlios_free(res)
+#define vec_znx_dft_spqlios_alloc(module, size) spqlios_alloc(fft64_bytes_of_vec_znx_dft(module, size))
+#define vec_znx_dft_spqlios_free(res) spqlios_free(res)
+#define vmp_pmat_spqlios_alloc(module, nrows, ncols) spqlios_alloc(fft64_bytes_of_vmp_pmat(module, nrows, ncols))
+#define vmp_pmat_spqlios_free(res) spqlios_free(res)
 #endif
 
 #define USE_LIBM_SIN_COS

--- a/spqlios/commons.h
+++ b/spqlios/commons.h
@@ -59,26 +59,6 @@ EXPORT void spqlios_free(void* address);
 EXPORT void* spqlios_alloc(uint64_t size);
 EXPORT void* spqlios_alloc_custom_align(uint64_t align, uint64_t size);
 
-#ifndef NDEBUG
-#define svp_ppol_spqlios_alloc(module) spqlios_debug_alloc(fft64_bytes_of_svp_ppol(module))
-#define svp_ppol_spqlios_free(ppol) spqlios_debug_free(ppol)
-#define vec_znx_big_spqlios_alloc(module, size) spqlios_debug_alloc(fft64_bytes_of_vec_znx_big(module, size))
-#define vec_znx_big_spqlios_free(res) spqlios_debug_free(res)
-#define vec_znx_dft_spqlios_alloc(module, size) spqlios_debug_alloc(fft64_bytes_of_vec_znx_dft(module, size))
-#define vec_znx_dft_spqlios_free(res) spqlios_debug_free(res)
-#define vmp_pmat_spqlios_alloc(module, nrows, ncols) spqlios_debug_alloc(fft64_bytes_of_vmp_pmat(module, nrows, ncols))
-#define vmp_pmat_spqlios_free(res) spqlios_debug_free(res)
-#else
-#define svp_ppol_spqlios_alloc(module) spqlios_alloc(fft64_bytes_of_svp_ppol(module))
-#define svp_ppol_spqlios_free(ppol) spqlios_free(ppol)
-#define vec_znx_big_spqlios_alloc(module, size) spqlios_alloc(fft64_bytes_of_vec_znx_big(module, size))
-#define vec_znx_big_spqlios_free(res) spqlios_free(res)
-#define vec_znx_dft_spqlios_alloc(module, size) spqlios_alloc(fft64_bytes_of_vec_znx_dft(module, size))
-#define vec_znx_dft_spqlios_free(res) spqlios_free(res)
-#define vmp_pmat_spqlios_alloc(module, nrows, ncols) spqlios_alloc(fft64_bytes_of_vmp_pmat(module, nrows, ncols))
-#define vmp_pmat_spqlios_free(res) spqlios_free(res)
-#endif
-
 #define USE_LIBM_SIN_COS
 #ifndef USE_LIBM_SIN_COS
 // if at some point, we want to remove the libm dependency, we can

--- a/spqlios/commons_private.h
+++ b/spqlios/commons_private.h
@@ -31,9 +31,9 @@ EXPORT uint64_t is_not_pow2_double(void* doublevalue);
     abort();                                 \
   }
 #define NOT_SUPPORTED()                    \
-  {                                          \
+  {                                        \
     fprintf(stderr, "NOT SUPPORTED!!!\n"); \
-    abort();                                 \
+    abort();                               \
   }
 #define FATAL_ERROR(MESSAGE)                   \
   {                                            \

--- a/spqlios/q120/q120_ntt.c
+++ b/spqlios/q120/q120_ntt.c
@@ -13,7 +13,7 @@ q120_ntt_precomp* new_precomp(const uint64_t n) {
   const uint64_t logN = ceil(log2(n));
   precomp->level_metadata = malloc((logN + 2) * sizeof(*precomp->level_metadata));
 
-  precomp->powomega = aligned_alloc(32, 4 * 2 * n * sizeof(*(precomp->powomega)));
+  precomp->powomega = spqlios_alloc_custom_align(32, 4 * 2 * n * sizeof(*(precomp->powomega)));
 
   return precomp;
 }
@@ -330,7 +330,7 @@ EXPORT q120_ntt_precomp* q120_new_intt_bb_precomp(const uint64_t n) {
 }
 
 void del_precomp(q120_ntt_precomp* precomp) {
-  free(precomp->powomega);
+  spqlios_free(precomp->powomega);
   free(precomp->level_metadata);
   free(precomp);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,114 +1,132 @@
 set(CMAKE_CXX_STANDARD 17)
 
-set(test_incs ..)
-set(gtest_libs)
-set(benchmark_libs)
-# searching for libgtest
-find_path(gtest_inc NAMES gtest/gtest.h)
-find_library(gtest NAMES gtest)
-find_library(gtest_main REQUIRED NAMES gtest_main)
-if (gtest_inc AND gtest AND gtest_main)
-	message(STATUS "Found gtest: I=${gtest_inc} L=${gtest},${gtest_main}")
-	set(test_incs ${test_incs} ${gtest_inc})
-	set(gtest_libs ${gtest_libs} ${gtest} ${gtest_main} pthread)
-else()
-	message(FATAL_ERROR "Libgtest not found (required if ENABLE_TESTING is on): I=${gtest_inc} L=${gtest},${gtest_main}")
-endif()
-# searching for libbenchmark
-find_path(benchmark_inc NAMES benchmark/benchmark.h)
-find_library(benchmark NAMES benchmark)
-if (benchmark_inc AND benchmark)
-        message(STATUS "Found benchmark: I=${benchmark_inc} L=${benchmark}")
-	set(test_incs ${test_incs} ${benchmark_inc})
-	set(benchmark_libs ${benchmark_libs} ${benchmark})
-else()
-	message(FATAL_ERROR "Libbenchmark not found (required if ENABLE_TESTING is on): I=${benchmark_inc} L=${benchmark}")
-endif()
-find_path(VALGRIND_DIR NAMES valgrind/valgrind.h)
-if (VALGRIND_DIR)
-	message(STATUS "Found valgrind header ${VALGRIND_DIR}")
-else ()
-	# for now, we will fail if we don't find valgrind for tests
-	message(STATUS "CANNOT FIND valgrind header: ${VALGRIND_DIR}")
-endif ()
+    set(test_incs..) set(gtest_libs) set(benchmark_libs)
+#searching for libgtest
+        find_path(gtest_inc NAMES gtest / gtest.h) find_library(gtest NAMES gtest)
+            find_library(gtest_main REQUIRED NAMES gtest_main) if (gtest_inc AND gtest AND gtest_main) message(
+                STATUS "Found gtest: I=${gtest_inc} L=${gtest},${gtest_main}") set(test_incs ${test_incs} ${
+                gtest_inc}) set(gtest_libs ${gtest_libs} ${gtest} ${
+                gtest_main} pthread) else() message(FATAL_ERROR
+                                                    "Libgtest not found (required if ENABLE_TESTING is on): "
+                                                    "I=${gtest_inc} L=${gtest},${gtest_main}") endif()
+#searching for libbenchmark
+                find_path(benchmark_inc NAMES benchmark / benchmark.h) find_library(benchmark NAMES benchmark) if (
+                    benchmark_inc AND
+                        benchmark) message(STATUS "Found benchmark: I=${benchmark_inc} L=${benchmark}") set(test_incs ${
+                    test_incs} ${benchmark_inc}) set(benchmark_libs ${benchmark_libs} ${
+                    benchmark}) else() message(FATAL_ERROR
+                                               "Libbenchmark not found (required if ENABLE_TESTING is on): "
+                                               "I=${benchmark_inc} L=${benchmark}") endif()
+                    find_path(VALGRIND_DIR NAMES valgrind / valgrind.h) if (VALGRIND_DIR) message(
+                        STATUS "Found valgrind header ${VALGRIND_DIR}") else()
+#for now, we will fail if we don't find valgrind for tests
+                        message(STATUS "CANNOT FIND valgrind header: ${VALGRIND_DIR}") endif()
 
-add_library(spqlios-testlib SHARED
-		testlib/random.cpp
-		testlib/test_commons.h
-		testlib/test_commons.cpp
-		testlib/mod_q120.h
-		testlib/mod_q120.cpp
-		testlib/negacyclic_polynomial.cpp
-		testlib/negacyclic_polynomial.h
-		testlib/negacyclic_polynomial_impl.h
-		testlib/reim4_elem.cpp
-		testlib/reim4_elem.h
-		testlib/fft64_dft.cpp
-		testlib/fft64_dft.h
-		testlib/fft64_layouts.h
-		testlib/fft64_layouts.cpp
-		testlib/ntt120_layouts.cpp
-		testlib/ntt120_layouts.h
-		testlib/ntt120_dft.cpp
-		testlib/ntt120_dft.h
-		testlib/test_hash.cpp
-		testlib/sha3.h
-		testlib/sha3.c
-		testlib/polynomial_vector.h
-		testlib/polynomial_vector.cpp
-)
-if (VALGRIND_DIR)
-	target_include_directories(spqlios-testlib PRIVATE ${VALGRIND_DIR})
-	target_compile_definitions(spqlios-testlib PRIVATE VALGRIND_MEM_TESTS)
-endif ()
-target_link_libraries(spqlios-testlib libspqlios)
+                            add_library(
+                                spqlios -
+                                testlib SHARED testlib /
+                                    random.cpp testlib /
+                                    test_commons
+                                        .h testlib /
+                                    test_commons
+                                        .cpp testlib /
+                                    mod_q120
+                                        .h testlib /
+                                    mod_q120
+                                        .cpp testlib /
+                                    negacyclic_polynomial
+                                        .cpp testlib /
+                                    negacyclic_polynomial
+                                        .h testlib /
+                                    negacyclic_polynomial_impl
+                                        .h testlib /
+                                    reim4_elem.cpp testlib /
+                                    reim4_elem.h testlib /
+                                    fft64_dft.cpp testlib /
+                                    fft64_dft
+                                        .h testlib /
+                                    fft64_layouts
+                                        .h testlib /
+                                    fft64_layouts.cpp testlib /
+                                    ntt120_layouts.cpp testlib / ntt120_layouts.h testlib / ntt120_dft.cpp testlib /
+                                    ntt120_dft.h testlib /
+                                    test_hash.cpp testlib /
+                                    sha3.h testlib /
+                                    sha3.c testlib /
+                                    polynomial_vector
+                                        .h testlib /
+                                    polynomial_vector.cpp) if (VALGRIND_DIR)
+                                target_include_directories(spqlios - testlib PRIVATE ${VALGRIND_DIR}) target_compile_definitions(
+                                    spqlios -
+                                    testlib
+                                        PRIVATE
+                                            VALGRIND_MEM_TESTS) endif() target_link_libraries(spqlios - testlib libspqlios)
 
+#main unittest file
+                                    message(
+                                        STATUS
+                                        "${gtest_libs}") set(UNITTEST_FILES spqlios_test
+                                                                 .cpp spqlios_reim_conversions_test
+                                                                 .cpp spqlios_reim_test
+                                                                 .cpp spqlios_reim4_arithmetic_test
+                                                                 .cpp spqlios_cplx_test
+                                                                 .cpp spqlios_cplx_conversions_test
+                                                                 .cpp spqlios_q120_ntt_test
+                                                                 .cpp spqlios_q120_arithmetic_test
+                                                                 .cpp spqlios_coeffs_arithmetic_test
+                                                                 .cpp spqlios_vec_znx_big_test
+                                                                 .cpp spqlios_znx_small_test
+                                                                 .cpp spqlios_vmp_product_test
+                                                                 .cpp spqlios_vec_znx_dft_test.cpp spqlios_svp_test
+                                                                 .cpp spqlios_svp_product_test.cpp spqlios_vec_znx_test
+                                                                 .cpp)
 
+                                        add_executable(spqlios - test ${UNITTEST_FILES}) target_link_libraries(
+                                            spqlios - test spqlios - testlib libspqlios ${gtest_libs})
+                                            target_include_directories(spqlios - test PRIVATE ${test_incs}) add_test(
+                                                NAME spqlios -
+                                                test COMMAND spqlios - test)
 
-# main unittest file
-message(STATUS "${gtest_libs}")
-set(UNITTEST_FILES
-		spqlios_test.cpp
-		spqlios_reim_conversions_test.cpp
-		spqlios_reim_test.cpp
-		spqlios_reim4_arithmetic_test.cpp
-		spqlios_cplx_test.cpp
-		spqlios_cplx_conversions_test.cpp
-		spqlios_q120_ntt_test.cpp
-		spqlios_q120_arithmetic_test.cpp
-		spqlios_coeffs_arithmetic_test.cpp
-		spqlios_vec_znx_big_test.cpp
-		spqlios_znx_small_test.cpp
-		spqlios_vmp_product_test.cpp
-		spqlios_vec_znx_dft_test.cpp
-		spqlios_svp_test.cpp
-		spqlios_svp_product_test.cpp
-		spqlios_vec_znx_test.cpp
-)
+#benchmarks
+                                                add_executable(spqlios - cplx - fft - bench spqlios_cplx_fft_bench.cpp)
+                                                    target_link_libraries(
+                                                        spqlios - cplx - fft -
+                                                        bench libspqlios ${benchmark_libs} pthread)
+                                                        target_include_directories(spqlios - cplx - fft -
+                                                                                   bench PRIVATE ${test_incs})
 
-add_executable(spqlios-test ${UNITTEST_FILES})
-target_link_libraries(spqlios-test spqlios-testlib libspqlios ${gtest_libs})
-target_include_directories(spqlios-test PRIVATE ${test_incs})
-add_test(NAME spqlios-test COMMAND spqlios-test)
+                                                            if (X86 OR X86_WIN32) add_executable(
+                                                                spqlios -
+                                                                q120 - ntt - bench spqlios_q120_ntt_bench.cpp)
+                                                                target_link_libraries(
+                                                                    spqlios - q120 - ntt -
+                                                                    bench libspqlios ${benchmark_libs} pthread)
+                                                                    target_include_directories(spqlios - q120 - ntt -
+                                                                                               bench PRIVATE ${
+                                                                                                   test_incs})
 
+                                                                        add_executable(
+                                                                            spqlios - q120 - arithmetic -
+                                                                            bench spqlios_q120_arithmetic_bench
+                                                                                .cpp)
+                                                                            target_link_libraries(
+                                                                                spqlios - q120 - arithmetic -
+                                                                                bench libspqlios ${
+                                                                                    benchmark_libs} pthread)
+                                                                                target_include_directories(
+                                                                                    spqlios - q120 - arithmetic -
+                                                                                    bench PRIVATE ${test_incs}) endif()
 
-# benchmarks
-add_executable(spqlios-cplx-fft-bench spqlios_cplx_fft_bench.cpp)
-target_link_libraries(spqlios-cplx-fft-bench libspqlios ${benchmark_libs} pthread)
-target_include_directories(spqlios-cplx-fft-bench PRIVATE ${test_incs})
-
-if (X86 OR X86_WIN32)
-    add_executable(spqlios-q120-ntt-bench spqlios_q120_ntt_bench.cpp)
-    target_link_libraries(spqlios-q120-ntt-bench libspqlios ${benchmark_libs} pthread)
-    target_include_directories(spqlios-q120-ntt-bench PRIVATE ${test_incs})
-
-    add_executable(spqlios-q120-arithmetic-bench spqlios_q120_arithmetic_bench.cpp)
-    target_link_libraries(spqlios-q120-arithmetic-bench libspqlios  ${benchmark_libs} pthread)
-    target_include_directories(spqlios-q120-arithmetic-bench PRIVATE ${test_incs})
-endif ()
-
-if (X86 OR X86_WIN32)
-	add_executable(spqlios_reim4_arithmetic_bench spqlios_reim4_arithmetic_bench.cpp)
-	target_link_libraries(spqlios_reim4_arithmetic_bench ${benchmark_libs} libspqlios pthread)
-	target_include_directories(spqlios_reim4_arithmetic_bench PRIVATE ${test_incs})
-endif ()
+                                                                                    if (X86 OR X86_WIN32) add_executable(
+                                                                                        spqlios_reim4_arithmetic_bench
+                                                                                            spqlios_reim4_arithmetic_bench
+                                                                                                .cpp)
+                                                                                        target_link_libraries(
+                                                                                            spqlios_reim4_arithmetic_bench
+                                                                                                ${benchmark_libs} libspqlios
+                                                                                                    pthread)
+                                                                                            target_include_directories(
+                                                                                                spqlios_reim4_arithmetic_bench
+                                                                                                    PRIVATE ${
+                                                                                                        test_incs})
+                                                                                                endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,132 +1,114 @@
 set(CMAKE_CXX_STANDARD 17)
 
-    set(test_incs..) set(gtest_libs) set(benchmark_libs)
-#searching for libgtest
-        find_path(gtest_inc NAMES gtest / gtest.h) find_library(gtest NAMES gtest)
-            find_library(gtest_main REQUIRED NAMES gtest_main) if (gtest_inc AND gtest AND gtest_main) message(
-                STATUS "Found gtest: I=${gtest_inc} L=${gtest},${gtest_main}") set(test_incs ${test_incs} ${
-                gtest_inc}) set(gtest_libs ${gtest_libs} ${gtest} ${
-                gtest_main} pthread) else() message(FATAL_ERROR
-                                                    "Libgtest not found (required if ENABLE_TESTING is on): "
-                                                    "I=${gtest_inc} L=${gtest},${gtest_main}") endif()
-#searching for libbenchmark
-                find_path(benchmark_inc NAMES benchmark / benchmark.h) find_library(benchmark NAMES benchmark) if (
-                    benchmark_inc AND
-                        benchmark) message(STATUS "Found benchmark: I=${benchmark_inc} L=${benchmark}") set(test_incs ${
-                    test_incs} ${benchmark_inc}) set(benchmark_libs ${benchmark_libs} ${
-                    benchmark}) else() message(FATAL_ERROR
-                                               "Libbenchmark not found (required if ENABLE_TESTING is on): "
-                                               "I=${benchmark_inc} L=${benchmark}") endif()
-                    find_path(VALGRIND_DIR NAMES valgrind / valgrind.h) if (VALGRIND_DIR) message(
-                        STATUS "Found valgrind header ${VALGRIND_DIR}") else()
-#for now, we will fail if we don't find valgrind for tests
-                        message(STATUS "CANNOT FIND valgrind header: ${VALGRIND_DIR}") endif()
+set(test_incs ..)
+set(gtest_libs)
+set(benchmark_libs)
+# searching for libgtest
+find_path(gtest_inc NAMES gtest/gtest.h)
+find_library(gtest NAMES gtest)
+find_library(gtest_main REQUIRED NAMES gtest_main)
+if (gtest_inc AND gtest AND gtest_main)
+    message(STATUS "Found gtest: I=${gtest_inc} L=${gtest},${gtest_main}")
+    set(test_incs ${test_incs} ${gtest_inc})
+    set(gtest_libs ${gtest_libs} ${gtest} ${gtest_main} pthread)
+else()
+    message(FATAL_ERROR "Libgtest not found (required if ENABLE_TESTING is on): I=${gtest_inc} L=${gtest},${gtest_main}")
+endif()
+# searching for libbenchmark
+find_path(benchmark_inc NAMES benchmark/benchmark.h)
+find_library(benchmark NAMES benchmark)
+if (benchmark_inc AND benchmark)
+    message(STATUS "Found benchmark: I=${benchmark_inc} L=${benchmark}")
+    set(test_incs ${test_incs} ${benchmark_inc})
+    set(benchmark_libs ${benchmark_libs} ${benchmark})
+else()
+    message(FATAL_ERROR "Libbenchmark not found (required if ENABLE_TESTING is on): I=${benchmark_inc} L=${benchmark}")
+endif()
+find_path(VALGRIND_DIR NAMES valgrind/valgrind.h)
+if (VALGRIND_DIR)
+    message(STATUS "Found valgrind header ${VALGRIND_DIR}")
+else ()
+    # for now, we will fail if we don't find valgrind for tests
+    message(STATUS "CANNOT FIND valgrind header: ${VALGRIND_DIR}")
+endif ()
 
-                            add_library(
-                                spqlios -
-                                testlib SHARED testlib /
-                                    random.cpp testlib /
-                                    test_commons
-                                        .h testlib /
-                                    test_commons
-                                        .cpp testlib /
-                                    mod_q120
-                                        .h testlib /
-                                    mod_q120
-                                        .cpp testlib /
-                                    negacyclic_polynomial
-                                        .cpp testlib /
-                                    negacyclic_polynomial
-                                        .h testlib /
-                                    negacyclic_polynomial_impl
-                                        .h testlib /
-                                    reim4_elem.cpp testlib /
-                                    reim4_elem.h testlib /
-                                    fft64_dft.cpp testlib /
-                                    fft64_dft
-                                        .h testlib /
-                                    fft64_layouts
-                                        .h testlib /
-                                    fft64_layouts.cpp testlib /
-                                    ntt120_layouts.cpp testlib / ntt120_layouts.h testlib / ntt120_dft.cpp testlib /
-                                    ntt120_dft.h testlib /
-                                    test_hash.cpp testlib /
-                                    sha3.h testlib /
-                                    sha3.c testlib /
-                                    polynomial_vector
-                                        .h testlib /
-                                    polynomial_vector.cpp) if (VALGRIND_DIR)
-                                target_include_directories(spqlios - testlib PRIVATE ${VALGRIND_DIR}) target_compile_definitions(
-                                    spqlios -
-                                    testlib
-                                        PRIVATE
-                                            VALGRIND_MEM_TESTS) endif() target_link_libraries(spqlios - testlib libspqlios)
+add_library(spqlios-testlib SHARED
+        testlib/random.cpp
+        testlib/test_commons.h
+        testlib/test_commons.cpp
+        testlib/mod_q120.h
+        testlib/mod_q120.cpp
+        testlib/negacyclic_polynomial.cpp
+        testlib/negacyclic_polynomial.h
+        testlib/negacyclic_polynomial_impl.h
+        testlib/reim4_elem.cpp
+        testlib/reim4_elem.h
+        testlib/fft64_dft.cpp
+        testlib/fft64_dft.h
+        testlib/fft64_layouts.h
+        testlib/fft64_layouts.cpp
+        testlib/ntt120_layouts.cpp
+        testlib/ntt120_layouts.h
+        testlib/ntt120_dft.cpp
+        testlib/ntt120_dft.h
+        testlib/test_hash.cpp
+        testlib/sha3.h
+        testlib/sha3.c
+        testlib/polynomial_vector.h
+        testlib/polynomial_vector.cpp
+)
+if (VALGRIND_DIR)
+    target_include_directories(spqlios-testlib PRIVATE ${VALGRIND_DIR})
+    target_compile_definitions(spqlios-testlib PRIVATE VALGRIND_MEM_TESTS)
+endif ()
+target_link_libraries(spqlios-testlib libspqlios)
 
-#main unittest file
-                                    message(
-                                        STATUS
-                                        "${gtest_libs}") set(UNITTEST_FILES spqlios_test
-                                                                 .cpp spqlios_reim_conversions_test
-                                                                 .cpp spqlios_reim_test
-                                                                 .cpp spqlios_reim4_arithmetic_test
-                                                                 .cpp spqlios_cplx_test
-                                                                 .cpp spqlios_cplx_conversions_test
-                                                                 .cpp spqlios_q120_ntt_test
-                                                                 .cpp spqlios_q120_arithmetic_test
-                                                                 .cpp spqlios_coeffs_arithmetic_test
-                                                                 .cpp spqlios_vec_znx_big_test
-                                                                 .cpp spqlios_znx_small_test
-                                                                 .cpp spqlios_vmp_product_test
-                                                                 .cpp spqlios_vec_znx_dft_test.cpp spqlios_svp_test
-                                                                 .cpp spqlios_svp_product_test.cpp spqlios_vec_znx_test
-                                                                 .cpp)
 
-                                        add_executable(spqlios - test ${UNITTEST_FILES}) target_link_libraries(
-                                            spqlios - test spqlios - testlib libspqlios ${gtest_libs})
-                                            target_include_directories(spqlios - test PRIVATE ${test_incs}) add_test(
-                                                NAME spqlios -
-                                                test COMMAND spqlios - test)
 
-#benchmarks
-                                                add_executable(spqlios - cplx - fft - bench spqlios_cplx_fft_bench.cpp)
-                                                    target_link_libraries(
-                                                        spqlios - cplx - fft -
-                                                        bench libspqlios ${benchmark_libs} pthread)
-                                                        target_include_directories(spqlios - cplx - fft -
-                                                                                   bench PRIVATE ${test_incs})
+# main unittest file
+message(STATUS "${gtest_libs}")
+set(UNITTEST_FILES
+        spqlios_test.cpp
+        spqlios_reim_conversions_test.cpp
+        spqlios_reim_test.cpp
+        spqlios_reim4_arithmetic_test.cpp
+        spqlios_cplx_test.cpp
+        spqlios_cplx_conversions_test.cpp
+        spqlios_q120_ntt_test.cpp
+        spqlios_q120_arithmetic_test.cpp
+        spqlios_coeffs_arithmetic_test.cpp
+        spqlios_vec_znx_big_test.cpp
+        spqlios_znx_small_test.cpp
+        spqlios_vmp_product_test.cpp
+        spqlios_vec_znx_dft_test.cpp
+        spqlios_svp_test.cpp
+        spqlios_svp_product_test.cpp
+        spqlios_vec_znx_test.cpp
+)
 
-                                                            if (X86 OR X86_WIN32) add_executable(
-                                                                spqlios -
-                                                                q120 - ntt - bench spqlios_q120_ntt_bench.cpp)
-                                                                target_link_libraries(
-                                                                    spqlios - q120 - ntt -
-                                                                    bench libspqlios ${benchmark_libs} pthread)
-                                                                    target_include_directories(spqlios - q120 - ntt -
-                                                                                               bench PRIVATE ${
-                                                                                                   test_incs})
+add_executable(spqlios-test ${UNITTEST_FILES})
+target_link_libraries(spqlios-test spqlios-testlib libspqlios ${gtest_libs})
+target_include_directories(spqlios-test PRIVATE ${test_incs})
+add_test(NAME spqlios-test COMMAND spqlios-test)
 
-                                                                        add_executable(
-                                                                            spqlios - q120 - arithmetic -
-                                                                            bench spqlios_q120_arithmetic_bench
-                                                                                .cpp)
-                                                                            target_link_libraries(
-                                                                                spqlios - q120 - arithmetic -
-                                                                                bench libspqlios ${
-                                                                                    benchmark_libs} pthread)
-                                                                                target_include_directories(
-                                                                                    spqlios - q120 - arithmetic -
-                                                                                    bench PRIVATE ${test_incs}) endif()
 
-                                                                                    if (X86 OR X86_WIN32) add_executable(
-                                                                                        spqlios_reim4_arithmetic_bench
-                                                                                            spqlios_reim4_arithmetic_bench
-                                                                                                .cpp)
-                                                                                        target_link_libraries(
-                                                                                            spqlios_reim4_arithmetic_bench
-                                                                                                ${benchmark_libs} libspqlios
-                                                                                                    pthread)
-                                                                                            target_include_directories(
-                                                                                                spqlios_reim4_arithmetic_bench
-                                                                                                    PRIVATE ${
-                                                                                                        test_incs})
-                                                                                                endif()
+# benchmarks
+add_executable(spqlios-cplx-fft-bench spqlios_cplx_fft_bench.cpp)
+target_link_libraries(spqlios-cplx-fft-bench libspqlios ${benchmark_libs} pthread)
+target_include_directories(spqlios-cplx-fft-bench PRIVATE ${test_incs})
+
+if (X86 OR X86_WIN32)
+    add_executable(spqlios-q120-ntt-bench spqlios_q120_ntt_bench.cpp)
+    target_link_libraries(spqlios-q120-ntt-bench libspqlios ${benchmark_libs} pthread)
+    target_include_directories(spqlios-q120-ntt-bench PRIVATE ${test_incs})
+
+    add_executable(spqlios-q120-arithmetic-bench spqlios_q120_arithmetic_bench.cpp)
+    target_link_libraries(spqlios-q120-arithmetic-bench libspqlios  ${benchmark_libs} pthread)
+    target_include_directories(spqlios-q120-arithmetic-bench PRIVATE ${test_incs})
+endif ()
+
+if (X86 OR X86_WIN32)
+    add_executable(spqlios_reim4_arithmetic_bench spqlios_reim4_arithmetic_bench.cpp)
+    target_link_libraries(spqlios_reim4_arithmetic_bench ${benchmark_libs} libspqlios pthread)
+    target_include_directories(spqlios_reim4_arithmetic_bench PRIVATE ${test_incs})
+endif ()

--- a/test/spqlios_cplx_conversions_test.cpp
+++ b/test/spqlios_cplx_conversions_test.cpp
@@ -8,7 +8,7 @@
 #ifdef __x86_64__
 TEST(fft, cplx_from_znx32_ref_vs_fma) {
   const uint32_t m = 128;
-  int32_t* src = (int32_t*)aligned_alloc(32, 10 * m * sizeof(int32_t));
+  int32_t* src = (int32_t*)spqlios_alloc_custom_align(32, 10 * m * sizeof(int32_t));
   CPLX* dst1 = (CPLX*)(src + 2 * m);
   CPLX* dst2 = (CPLX*)(src + 6 * m);
   for (uint64_t i = 0; i < 2 * m; ++i) {
@@ -23,13 +23,14 @@ TEST(fft, cplx_from_znx32_ref_vs_fma) {
     ASSERT_EQ(dst1[i][0], dst2[i][0]);
     ASSERT_EQ(dst1[i][1], dst2[i][1]);
   }
+  spqlios_free(src);
 }
 #endif
 
 #ifdef __x86_64__
 TEST(fft, cplx_from_tnx32_ref_vs_fma) {
   const uint32_t m = 128;
-  int32_t* src = (int32_t*)aligned_alloc(32, 10 * m * sizeof(int32_t));
+  int32_t* src = (int32_t*)spqlios_alloc_custom_align(32, 10 * m * sizeof(int32_t));
   CPLX* dst1 = (CPLX*)(src + 2 * m);
   CPLX* dst2 = (CPLX*)(src + 6 * m);
   for (uint64_t i = 0; i < 2 * m; ++i) {
@@ -44,6 +45,7 @@ TEST(fft, cplx_from_tnx32_ref_vs_fma) {
     ASSERT_EQ(dst1[i][0], dst2[i][0]);
     ASSERT_EQ(dst1[i][1], dst2[i][1]);
   }
+  spqlios_free(src);
 }
 #endif
 
@@ -51,7 +53,7 @@ TEST(fft, cplx_from_tnx32_ref_vs_fma) {
 TEST(fft, cplx_to_tnx32_ref_vs_fma) {
   for (const uint32_t m : {8, 128, 1024, 65536}) {
     for (const double divisor : {double(1), double(m), double(0.5)}) {
-      CPLX* src = (CPLX*)aligned_alloc(32, 10 * m * sizeof(int32_t));
+      CPLX* src = (CPLX*)spqlios_alloc_custom_align(32, 10 * m * sizeof(int32_t));
       int32_t* dst1 = (int32_t*)(src + m);
       int32_t* dst2 = (int32_t*)(src + 2 * m);
       for (uint64_t i = 0; i < 2 * m; ++i) {
@@ -77,7 +79,7 @@ TEST(fft, cplx_to_tnx32_ref_vs_fma) {
               << i << " " << dst1[i] << " " << dst2[i] << " " << truevalue << std::endl;
         }
       }
-      free(src);
+      spqlios_free(src);
     }
   }
 }

--- a/test/spqlios_cplx_test.cpp
+++ b/test/spqlios_cplx_test.cpp
@@ -22,8 +22,8 @@ TEST(fft, ifft16_fma_vs_ref) {
   for (uint64_t i = 0; i < 16; ++i) {
     double d1 = fabs(data[i][0] - copydata[i][0]);
     double d2 = fabs(data[i][0] - copydata[i][0]);
-    if (d1>distance) distance=d1;
-    if (d2>distance) distance=d2;
+    if (d1 > distance) distance = d1;
+    if (d2 > distance) distance = d2;
   }
   /*
   printf("data:\n");
@@ -201,9 +201,9 @@ TEST(fft, halfcfft_ref_vs_naive) {
   for (uint64_t nn : {4, 8, 16, 64, 256, 8192}) {
     uint64_t m = nn / 2;
     CPLX_FFT_PRECOMP* tables = new_cplx_fft_precomp(m, 0);
-    CPLX* a = (CPLX*)aligned_alloc(32, m * sizeof(CPLX));
-    CPLX* a1 = (CPLX*)aligned_alloc(32, m * sizeof(CPLX));
-    CPLX* a2 = (CPLX*)aligned_alloc(32, m * sizeof(CPLX));
+    CPLX* a = (CPLX*)spqlios_alloc_custom_align(32, m * sizeof(CPLX));
+    CPLX* a1 = (CPLX*)spqlios_alloc_custom_align(32, m * sizeof(CPLX));
+    CPLX* a2 = (CPLX*)spqlios_alloc_custom_align(32, m * sizeof(CPLX));
     int64_t p = 1 << 16;
     for (uint32_t i = 0; i < m; i++) {
       a[i][0] = (rand() % p) - p / 2;  // between -p/2 and p/2
@@ -223,9 +223,9 @@ TEST(fft, halfcfft_ref_vs_naive) {
       if (dim > d) d = dim;
     }
     ASSERT_LE(d, nn * 1e-10) << nn;
-    free(a);
-    free(a1);
-    free(a2);
+    spqlios_free(a);
+    spqlios_free(a1);
+    spqlios_free(a2);
     delete_cplx_fft_precomp(tables);
   }
 }
@@ -237,9 +237,9 @@ TEST(fft, halfcfft_fma_vs_ref) {
     for (uint64_t nn : {8, 16, 32, 64, 1024, 8192, 65536}) {
       uint64_t m = nn / 2;
       CPLX_FFT_PRECOMP* tables = new_cplx_fft_precomp(m, 0);
-      CPLX* a = (CPLX*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-      CPLX* a1 = (CPLX*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-      CPLX* a2 = (CPLX*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
+      CPLX* a = (CPLX*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+      CPLX* a1 = (CPLX*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+      CPLX* a2 = (CPLX*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
       int64_t p = 1 << 16;
       for (uint32_t i = 0; i < nn / 2; i++) {
         a[i][0] = (rand() % p) - p / 2;  // between -p/2 and p/2
@@ -257,9 +257,9 @@ TEST(fft, halfcfft_fma_vs_ref) {
         if (dim > d) d = dim;
       }
       ASSERT_LE(d, nn * 1e-10) << nn;
-      free(a);
-      free(a1);
-      free(a2);
+      spqlios_free(a);
+      spqlios_free(a1);
+      spqlios_free(a2);
       delete_cplx_fft_precomp(tables);
     }
   }
@@ -271,8 +271,8 @@ TEST(fft, halfcfft_then_ifft_ref) {
     uint64_t m = nn / 2;
     CPLX_FFT_PRECOMP* tables = new_cplx_fft_precomp(m, 0);
     CPLX_IFFT_PRECOMP* itables = new_cplx_ifft_precomp(m, 0);
-    CPLX* a = (CPLX*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    CPLX* a1 = (CPLX*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
+    CPLX* a = (CPLX*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    CPLX* a1 = (CPLX*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
     int64_t p = 1 << 16;
     for (uint32_t i = 0; i < nn / 2; i++) {
       a[i][0] = (rand() % p) - p / 2;  // between -p/2 and p/2
@@ -289,8 +289,8 @@ TEST(fft, halfcfft_then_ifft_ref) {
       if (dim > d) d = dim;
     }
     ASSERT_LE(d, 1e-8);
-    free(a);
-    free(a1);
+    spqlios_free(a);
+    spqlios_free(a1);
     delete_cplx_fft_precomp(tables);
     delete_cplx_ifft_precomp(itables);
   }
@@ -302,9 +302,9 @@ TEST(fft, halfcfft_ifft_fma_vs_ref) {
     for (uint64_t nn : {8, 16, 32, 1024, 4096, 8192, 65536}) {
       uint64_t m = nn / 2;
       CPLX_IFFT_PRECOMP* itables = new_cplx_ifft_precomp(m, 0);
-      CPLX* a = (CPLX*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-      CPLX* a1 = (CPLX*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-      CPLX* a2 = (CPLX*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
+      CPLX* a = (CPLX*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+      CPLX* a1 = (CPLX*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+      CPLX* a2 = (CPLX*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
       int64_t p = 1 << 16;
       for (uint32_t i = 0; i < nn / 2; i++) {
         a[i][0] = (rand() % p) - p / 2;  // between -p/2 and p/2
@@ -322,9 +322,9 @@ TEST(fft, halfcfft_ifft_fma_vs_ref) {
         if (dim > d) d = dim;
       }
       ASSERT_LE(d, 1e-8);
-      free(a);
-      free(a1);
-      free(a2);
+      spqlios_free(a);
+      spqlios_free(a1);
+      spqlios_free(a2);
       delete_cplx_ifft_precomp(itables);
     }
   }

--- a/test/spqlios_reim_conversions_test.cpp
+++ b/test/spqlios_reim_conversions_test.cpp
@@ -5,8 +5,8 @@
 
 TEST(reim_conversions, reim_to_tnx) {
   for (uint32_t m : {1, 2, 64, 128, 512}) {
-    for (double divisor : {1,2,int(m)}) {
-      for (uint32_t log2overhead : {1,2,10,18,35, 42}) {
+    for (double divisor : {1, 2, int(m)}) {
+      for (uint32_t log2overhead : {1, 2, 10, 18, 35, 42}) {
         double maxdiff = pow(2., log2overhead - 50);
         std::vector<double> data(2 * m);
         std::vector<double> dout(2 * m);
@@ -27,13 +27,12 @@ TEST(reim_conversions, reim_to_tnx) {
   }
 }
 
-
 #ifdef __x86_64__
 TEST(reim_conversions, reim_to_tnx_ref_vs_avx) {
   for (uint32_t m : {8, 16, 64, 128, 512}) {
-    for (double divisor : {1,2,int(m)}) {
-      for (uint32_t log2overhead : {1,2,10,18,35, 42}) {
-        //double maxdiff = pow(2., log2overhead - 50);
+    for (double divisor : {1, 2, int(m)}) {
+      for (uint32_t log2overhead : {1, 2, 10, 18, 35, 42}) {
+        // double maxdiff = pow(2., log2overhead - 50);
         std::vector<double> data(2 * m);
         std::vector<double> dout1(2 * m);
         std::vector<double> dout2(2 * m);
@@ -44,7 +43,7 @@ TEST(reim_conversions, reim_to_tnx_ref_vs_avx) {
         reim_to_tnx_ref(p, dout1.data(), data.data());
         reim_to_tnx_avx(p, dout2.data(), data.data());
         for (uint64_t i = 0; i < 2 * m; ++i) {
-          ASSERT_LE(fabs(dout1[i]-dout2[i]), 0.);
+          ASSERT_LE(fabs(dout1[i] - dout2[i]), 0.);
         }
         delete_reim_to_tnx_precomp(p);
       }

--- a/test/spqlios_reim_test.cpp
+++ b/test/spqlios_reim_test.cpp
@@ -14,9 +14,9 @@ TEST(fft, reim_fft_avx2_vs_fft_reim_ref) {
     uint64_t m = nn / 2;
     // CPLX_FFT_PRECOMP* tables = new_cplx_fft_precomp(m, 0);
     REIM_FFT_PRECOMP* reimtables = new_reim_fft_precomp(m, 0);
-    CPLX* a = (CPLX*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* a1 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* a2 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
+    CPLX* a = (CPLX*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* a1 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* a2 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
     int64_t p = 1 << 16;
     for (uint32_t i = 0; i < nn / 2; i++) {
       a[i][0] = (rand() % p) - p / 2;  // between -p/2 and p/2
@@ -35,9 +35,9 @@ TEST(fft, reim_fft_avx2_vs_fft_reim_ref) {
       ASSERT_LE(d, nn * 1e-10) << nn;
     }
     ASSERT_LE(d, nn * 1e-10) << nn;
-    free(a);
-    free(a1);
-    free(a2);
+    spqlios_free(a);
+    spqlios_free(a1);
+    spqlios_free(a2);
     // delete_cplx_fft_precomp(tables);
     delete_reim_fft_precomp(reimtables);
   }
@@ -50,9 +50,9 @@ TEST(fft, reim_ifft_avx2_vs_reim_ifft_ref) {
     uint64_t m = nn / 2;
     // CPLX_FFT_PRECOMP* tables = new_cplx_fft_precomp(m, 0);
     REIM_IFFT_PRECOMP* reimtables = new_reim_ifft_precomp(m, 0);
-    CPLX* a = (CPLX*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* a1 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* a2 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
+    CPLX* a = (CPLX*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* a1 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* a2 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
     int64_t p = 1 << 16;
     for (uint32_t i = 0; i < nn / 2; i++) {
       a[i][0] = (rand() % p) - p / 2;  // between -p/2 and p/2
@@ -71,9 +71,9 @@ TEST(fft, reim_ifft_avx2_vs_reim_ifft_ref) {
       ASSERT_LE(d, 1e-8);
     }
     ASSERT_LE(d, 1e-8);
-    free(a);
-    free(a1);
-    free(a2);
+    spqlios_free(a);
+    spqlios_free(a1);
+    spqlios_free(a2);
     // delete_cplx_fft_precomp(tables);
     delete_reim_fft_precomp(reimtables);
   }
@@ -86,12 +86,12 @@ TEST(fft, reim_vecfft_addmul_fma_vs_ref) {
     uint64_t m = nn / 2;
     REIM_FFTVEC_ADDMUL_PRECOMP* tbl = new_reim_fftvec_addmul_precomp(m);
     ASSERT_TRUE(tbl != nullptr);
-    double* a1 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* a2 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* b1 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* b2 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* r1 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* r2 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
+    double* a1 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* a2 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* b1 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* b2 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* r1 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* r2 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
     int64_t p = 1 << 16;
     for (uint32_t i = 0; i < nn; i++) {
       a1[i] = (rand() % p) - p / 2;  // between -p/2 and p/2
@@ -110,12 +110,12 @@ TEST(fft, reim_vecfft_addmul_fma_vs_ref) {
       ASSERT_LE(d, 1e-8);
     }
     ASSERT_LE(d, 1e-8);
-    free(a1);
-    free(a2);
-    free(b1);
-    free(b2);
-    free(r1);
-    free(r2);
+    spqlios_free(a1);
+    spqlios_free(a2);
+    spqlios_free(b1);
+    spqlios_free(b2);
+    spqlios_free(r1);
+    spqlios_free(r2);
     delete_reim_fftvec_addmul_precomp(tbl);
   }
 }
@@ -126,12 +126,12 @@ TEST(fft, reim_vecfft_mul_fma_vs_ref) {
   for (uint64_t nn : {16, 32, 64, 1024, 8192, 65536}) {
     uint64_t m = nn / 2;
     REIM_FFTVEC_MUL_PRECOMP* tbl = new_reim_fftvec_mul_precomp(m);
-    double* a1 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* a2 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* b1 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* b2 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* r1 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* r2 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
+    double* a1 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* a2 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* b1 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* b2 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* r1 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* r2 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
     int64_t p = 1 << 16;
     for (uint32_t i = 0; i < nn; i++) {
       a1[i] = (rand() % p) - p / 2;  // between -p/2 and p/2
@@ -150,29 +150,26 @@ TEST(fft, reim_vecfft_mul_fma_vs_ref) {
       ASSERT_LE(d, 1e-8);
     }
     ASSERT_LE(d, 1e-8);
-    free(a1);
-    free(a2);
-    free(b1);
-    free(b2);
-    free(r1);
-    free(r2);
+    spqlios_free(a1);
+    spqlios_free(a2);
+    spqlios_free(b1);
+    spqlios_free(b2);
+    spqlios_free(r1);
+    spqlios_free(r2);
     delete_reim_fftvec_mul_precomp(tbl);
   }
 }
 #endif
 
-typedef void (*FILL_REIM_FFT_OMG_F)(const double entry_pwr, double **omg);
-typedef void (*REIM_FFT_F)(double *dre, double *dim, const void *omega);
+typedef void (*FILL_REIM_FFT_OMG_F)(const double entry_pwr, double** omg);
+typedef void (*REIM_FFT_F)(double* dre, double* dim, const void* omega);
 
 // template to test a fixed-dimension fft vs. naive
-template<uint64_t N>
-void test_reim_fft_ref_vs_naive(
-    FILL_REIM_FFT_OMG_F fill_omega_f,
-    REIM_FFT_F reim_fft_f
-    ) {
+template <uint64_t N>
+void test_reim_fft_ref_vs_naive(FILL_REIM_FFT_OMG_F fill_omega_f, REIM_FFT_F reim_fft_f) {
   double om[N];
-  double data[2*N];
-  double datacopy[2*N];
+  double data[2 * N];
+  double datacopy[2 * N];
   double* omg = om;
   fill_omega_f(0.25, &omg);
   ASSERT_EQ(omg - om, ptrdiff_t(N));  // it may depend on N
@@ -183,19 +180,17 @@ void test_reim_fft_ref_vs_naive(
   reim_fft_f(datacopy, datacopy + N, om);
   reim_naive_fft(N, 0.25, data, data + N);
   double d = 0;
-  for (uint64_t i = 0; i < 2*N; ++i) {
+  for (uint64_t i = 0; i < 2 * N; ++i) {
     d += fabs(datacopy[i] - data[i]);
   }
   ASSERT_LE(d, 1e-7);
 }
 
-template<uint64_t N>
-void test_reim_fft_ref_vs_accel(
-    REIM_FFT_F reim_fft_ref_f,
-    REIM_FFT_F reim_fft_accel_f) {
+template <uint64_t N>
+void test_reim_fft_ref_vs_accel(REIM_FFT_F reim_fft_ref_f, REIM_FFT_F reim_fft_accel_f) {
   double om[N];
-  double data[2*N];
-  double datacopy[2*N];
+  double data[2 * N];
+  double datacopy[2 * N];
   for (uint64_t i = 0; i < N; ++i) {
     om[i] = (rand() % 100) - 50;
     datacopy[i] = data[i] = (rand() % 100) - 50;
@@ -204,7 +199,7 @@ void test_reim_fft_ref_vs_accel(
   reim_fft_ref_f(datacopy, datacopy + N, om);
   reim_fft_accel_f(data, data + N, om);
   double d = 0;
-  for (uint64_t i = 0; i < 2*N; ++i) {
+  for (uint64_t i = 0; i < 2 * N; ++i) {
     d += fabs(datacopy[i] - data[i]);
   }
   if (d > 1e-15) {
@@ -215,39 +210,25 @@ void test_reim_fft_ref_vs_accel(
   }
 }
 
-TEST(fft, reim_fft16_ref_vs_naive) {
-  test_reim_fft_ref_vs_naive<16>(fill_reim_fft16_omegas, reim_fft16_ref);
-}
+TEST(fft, reim_fft16_ref_vs_naive) { test_reim_fft_ref_vs_naive<16>(fill_reim_fft16_omegas, reim_fft16_ref); }
 
 #ifdef __x86_64__
-TEST(fft, reim_fft16_ref_vs_fma) {
-  test_reim_fft_ref_vs_accel<16>(reim_fft16_ref, reim_fft16_avx_fma);
-}
+TEST(fft, reim_fft16_ref_vs_fma) { test_reim_fft_ref_vs_accel<16>(reim_fft16_ref, reim_fft16_avx_fma); }
 #endif
 
-TEST(fft, reim_fft8_ref_vs_naive) {
-  test_reim_fft_ref_vs_naive<8>(fill_reim_fft8_omegas, reim_fft8_ref);
-}
+TEST(fft, reim_fft8_ref_vs_naive) { test_reim_fft_ref_vs_naive<8>(fill_reim_fft8_omegas, reim_fft8_ref); }
 
 #ifdef __x86_64__
-TEST(fft, reim_fft8_ref_vs_fma) {
-  test_reim_fft_ref_vs_accel<8>(reim_fft8_ref, reim_fft8_avx_fma);
-}
+TEST(fft, reim_fft8_ref_vs_fma) { test_reim_fft_ref_vs_accel<8>(reim_fft8_ref, reim_fft8_avx_fma); }
 #endif
 
-TEST(fft, reim_fft4_ref_vs_naive) {
-  test_reim_fft_ref_vs_naive<4>(fill_reim_fft4_omegas, reim_fft4_ref);
-}
+TEST(fft, reim_fft4_ref_vs_naive) { test_reim_fft_ref_vs_naive<4>(fill_reim_fft4_omegas, reim_fft4_ref); }
 
 #ifdef __x86_64__
-TEST(fft, reim_fft4_ref_vs_fma) {
-  test_reim_fft_ref_vs_accel<4>(reim_fft4_ref, reim_fft4_avx_fma);
-}
+TEST(fft, reim_fft4_ref_vs_fma) { test_reim_fft_ref_vs_accel<4>(reim_fft4_ref, reim_fft4_avx_fma); }
 #endif
 
-TEST(fft, reim_fft2_ref_vs_naive) {
-  test_reim_fft_ref_vs_naive<2>(fill_reim_fft2_omegas, reim_fft2_ref);
-}
+TEST(fft, reim_fft2_ref_vs_naive) { test_reim_fft_ref_vs_naive<2>(fill_reim_fft2_omegas, reim_fft2_ref); }
 
 TEST(fft, reim_fft_bfs_16_ref_vs_naive) {
   for (const uint64_t m : {16, 32, 64, 128, 256, 512, 1024, 2048}) {
@@ -296,7 +277,7 @@ TEST(fft, reim_fft_rec_16_ref_vs_naive) {
 }
 
 TEST(fft, reim_fft_ref_vs_naive) {
-  for (const uint64_t m : {1,2,4,8,16,32,64,128,256,512,1024,2048, 4096, 8192, 32768, 65536}) {
+  for (const uint64_t m : {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 32768, 65536}) {
     std::vector<double> om(2 * m);
     std::vector<double> data(2 * m);
     std::vector<double> datacopy(2 * m);
@@ -316,19 +297,15 @@ TEST(fft, reim_fft_ref_vs_naive) {
   }
 }
 
-
-typedef void (*FILL_REIM_IFFT_OMG_F)(const double entry_pwr, double **omg);
-typedef void (*REIM_IFFT_F)(double *dre, double *dim, const void *omega);
+typedef void (*FILL_REIM_IFFT_OMG_F)(const double entry_pwr, double** omg);
+typedef void (*REIM_IFFT_F)(double* dre, double* dim, const void* omega);
 
 // template to test a fixed-dimension fft vs. naive
-template<uint64_t N>
-void test_reim_ifft_ref_vs_naive(
-    FILL_REIM_IFFT_OMG_F fill_omega_f,
-    REIM_IFFT_F reim_ifft_f
-) {
+template <uint64_t N>
+void test_reim_ifft_ref_vs_naive(FILL_REIM_IFFT_OMG_F fill_omega_f, REIM_IFFT_F reim_ifft_f) {
   double om[N];
-  double data[2*N];
-  double datacopy[2*N];
+  double data[2 * N];
+  double datacopy[2 * N];
   double* omg = om;
   fill_omega_f(0.25, &omg);
   ASSERT_EQ(omg - om, ptrdiff_t(N));  // it may depend on N
@@ -339,19 +316,17 @@ void test_reim_ifft_ref_vs_naive(
   reim_ifft_f(datacopy, datacopy + N, om);
   reim_naive_ifft(N, 0.25, data, data + N);
   double d = 0;
-  for (uint64_t i = 0; i < 2*N; ++i) {
+  for (uint64_t i = 0; i < 2 * N; ++i) {
     d += fabs(datacopy[i] - data[i]);
   }
   ASSERT_LE(d, 1e-7);
 }
 
-template<uint64_t N>
-void test_reim_ifft_ref_vs_accel(
-    REIM_IFFT_F reim_ifft_ref_f,
-    REIM_IFFT_F reim_ifft_accel_f) {
+template <uint64_t N>
+void test_reim_ifft_ref_vs_accel(REIM_IFFT_F reim_ifft_ref_f, REIM_IFFT_F reim_ifft_accel_f) {
   double om[N];
-  double data[2*N];
-  double datacopy[2*N];
+  double data[2 * N];
+  double datacopy[2 * N];
   for (uint64_t i = 0; i < N; ++i) {
     om[i] = (rand() % 100) - 50;
     datacopy[i] = data[i] = (rand() % 100) - 50;
@@ -360,7 +335,7 @@ void test_reim_ifft_ref_vs_accel(
   reim_ifft_ref_f(datacopy, datacopy + N, om);
   reim_ifft_accel_f(data, data + N, om);
   double d = 0;
-  for (uint64_t i = 0; i < 2*N; ++i) {
+  for (uint64_t i = 0; i < 2 * N; ++i) {
     d += fabs(datacopy[i] - data[i]);
   }
   if (d > 1e-15) {
@@ -371,39 +346,25 @@ void test_reim_ifft_ref_vs_accel(
   }
 }
 
-TEST(fft, reim_ifft16_ref_vs_naive) {
-  test_reim_ifft_ref_vs_naive<16>(fill_reim_ifft16_omegas, reim_ifft16_ref);
-}
+TEST(fft, reim_ifft16_ref_vs_naive) { test_reim_ifft_ref_vs_naive<16>(fill_reim_ifft16_omegas, reim_ifft16_ref); }
 
 #ifdef __x86_64__
-TEST(fft, reim_ifft16_ref_vs_fma) {
-  test_reim_ifft_ref_vs_accel<16>(reim_ifft16_ref, reim_ifft16_avx_fma);
-}
+TEST(fft, reim_ifft16_ref_vs_fma) { test_reim_ifft_ref_vs_accel<16>(reim_ifft16_ref, reim_ifft16_avx_fma); }
 #endif
 
-TEST(fft, reim_ifft8_ref_vs_naive) {
-  test_reim_ifft_ref_vs_naive<8>(fill_reim_ifft8_omegas, reim_ifft8_ref);
-}
+TEST(fft, reim_ifft8_ref_vs_naive) { test_reim_ifft_ref_vs_naive<8>(fill_reim_ifft8_omegas, reim_ifft8_ref); }
 
 #ifdef __x86_64__
-TEST(fft, reim_ifft8_ref_vs_fma) {
-  test_reim_ifft_ref_vs_accel<8>(reim_ifft8_ref, reim_ifft8_avx_fma);
-}
+TEST(fft, reim_ifft8_ref_vs_fma) { test_reim_ifft_ref_vs_accel<8>(reim_ifft8_ref, reim_ifft8_avx_fma); }
 #endif
 
-TEST(fft, reim_ifft4_ref_vs_naive) {
-  test_reim_ifft_ref_vs_naive<4>(fill_reim_ifft4_omegas, reim_ifft4_ref);
-}
+TEST(fft, reim_ifft4_ref_vs_naive) { test_reim_ifft_ref_vs_naive<4>(fill_reim_ifft4_omegas, reim_ifft4_ref); }
 
 #ifdef __x86_64__
-TEST(fft, reim_ifft4_ref_vs_fma) {
-  test_reim_ifft_ref_vs_accel<4>(reim_ifft4_ref, reim_ifft4_avx_fma);
-}
+TEST(fft, reim_ifft4_ref_vs_fma) { test_reim_ifft_ref_vs_accel<4>(reim_ifft4_ref, reim_ifft4_avx_fma); }
 #endif
 
-TEST(fft, reim_ifft2_ref_vs_naive) {
-  test_reim_ifft_ref_vs_naive<2>(fill_reim_ifft2_omegas, reim_ifft2_ref);
-}
+TEST(fft, reim_ifft2_ref_vs_naive) { test_reim_ifft_ref_vs_naive<2>(fill_reim_ifft2_omegas, reim_ifft2_ref); }
 
 TEST(fft, reim_ifft_bfs_16_ref_vs_naive) {
   for (const uint64_t m : {16, 32, 64, 128, 256, 512, 1024, 2048}) {
@@ -452,7 +413,7 @@ TEST(fft, reim_ifft_rec_16_ref_vs_naive) {
 }
 
 TEST(fft, reim_ifft_ref_vs_naive) {
-  for (const uint64_t m : {1,2,4,8,16,32,64,128,256,512,1024,2048, 4096, 8192, 32768, 65536}) {
+  for (const uint64_t m : {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 32768, 65536}) {
     std::vector<double> om(2 * m);
     std::vector<double> data(2 * m);
     std::vector<double> datacopy(2 * m);
@@ -471,6 +432,3 @@ TEST(fft, reim_ifft_ref_vs_naive) {
     delete_reim_ifft_precomp(precomp);
   }
 }
-
-
-

--- a/test/spqlios_test.cpp
+++ b/test/spqlios_test.cpp
@@ -29,10 +29,10 @@ TEST(fft, fftvec_convolution) {
   static const uint64_t k = 18;  // vary from 10 to 20
   // double* buf_fft = fft_precomp_get_buffer(tables, 0);
   // double* buf_ifft = ifft_precomp_get_buffer(itables, 0);
-  double* a = (double*)aligned_alloc(32, nn * 8);
-  double* a2 = (double*)aligned_alloc(32, nn * 8);
-  double* b = (double*)aligned_alloc(32, nn * 8);
-  double* dist_vector = (double*)aligned_alloc(32, nn * 8);
+  double* a = (double*)spqlios_alloc_custom_align(32, nn * 8);
+  double* a2 = (double*)spqlios_alloc_custom_align(32, nn * 8);
+  double* b = (double*)spqlios_alloc_custom_align(32, nn * 8);
+  double* dist_vector = (double*)spqlios_alloc_custom_align(32, nn * 8);
   int64_t p = UINT64_C(1) << k;
   printf("p size: %" PRId64 "\n", p);
   for (uint32_t i = 0; i < nn; i++) {
@@ -69,10 +69,10 @@ TEST(fft, fftvec_convolution) {
   double stdev = sqrt(variance / nn);
   printf("stdev: %lf\n", stdev);
 
-  free(a);
-  free(b);
-  free(a2);
-  free(dist_vector);
+  spqlios_free(a);
+  spqlios_free(b);
+  spqlios_free(a2);
+  spqlios_free(dist_vector);
 }
 
 typedef double CPLX[2];
@@ -156,9 +156,12 @@ TEST(fft, reim_vs_regular_layout_mul_test) {
   double c2[16] __attribute__((aligned(32)));    // for the result
   double c3[8][2] __attribute__((aligned(32)));  // for the result
 
-  double* a2 = (double*)aligned_alloc(32, nn / 2 * 2 * sizeof(double));  // for storing the coefs in reim layout
-  double* b2 = (double*)aligned_alloc(32, nn / 2 * 2 * sizeof(double));  // for storing the coefs in reim layout
-  // double* c2 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX)); // for storing the coefs in reim layout
+  double* a2 =
+      (double*)spqlios_alloc_custom_align(32, nn / 2 * 2 * sizeof(double));  // for storing the coefs in reim layout
+  double* b2 =
+      (double*)spqlios_alloc_custom_align(32, nn / 2 * 2 * sizeof(double));  // for storing the coefs in reim layout
+  // double* c2 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX)); // for storing the coefs in reim
+  // layout
 
   // organise the coefficients in the reim layout
   for (uint32_t i = 0; i < nn / 2; i++) {
@@ -211,17 +214,17 @@ TEST(fft, reim_vs_regular_layout_mul_test) {
   }
   ASSERT_LE(d, 1e-7);
 
-  free(a2);
-  free(b2);
-  // free(c2);
+  spqlios_free(a2);
+  spqlios_free(b2);
+  // spqlios_free(c2);
 }
 
 TEST(fft, fftvec_convolution_recursiveoverk) {
   static const uint64_t nn = 32768;  // vary accross (8192, 16384), 32768, 65536
-  double* a = (double*)aligned_alloc(32, nn * 8);
-  double* a2 = (double*)aligned_alloc(32, nn * 8);
-  double* b = (double*)aligned_alloc(32, nn * 8);
-  double* dist_vector = (double*)aligned_alloc(32, nn * 8);
+  double* a = (double*)spqlios_alloc_custom_align(32, nn * 8);
+  double* a2 = (double*)spqlios_alloc_custom_align(32, nn * 8);
+  double* b = (double*)spqlios_alloc_custom_align(32, nn * 8);
+  double* dist_vector = (double*)spqlios_alloc_custom_align(32, nn * 8);
 
   printf("N size: %" PRId64 "\n", nn);
 
@@ -258,10 +261,10 @@ TEST(fft, fftvec_convolution_recursiveoverk) {
     printf("stdev: %lf\n", stdev);
   }
 
-  free(a);
-  free(b);
-  free(a2);
-  free(dist_vector);
+  spqlios_free(a);
+  spqlios_free(b);
+  spqlios_free(a2);
+  spqlios_free(dist_vector);
 }
 
 #ifdef __x86_64__
@@ -270,9 +273,9 @@ TEST(fft, cplx_fft_ref_vs_fft_reim_ref) {
     uint64_t m = nn / 2;
     CPLX_FFT_PRECOMP* tables = new_cplx_fft_precomp(m, 0);
     REIM_FFT_PRECOMP* reimtables = new_reim_fft_precomp(m, 0);
-    CPLX* a = (CPLX*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    CPLX* a1 = (CPLX*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* a2 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
+    CPLX* a = (CPLX*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    CPLX* a1 = (CPLX*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* a2 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
     int64_t p = 1 << 16;
     for (uint32_t i = 0; i < nn / 2; i++) {
       a[i][0] = (rand() % p) - p / 2;  // between -p/2 and p/2
@@ -294,9 +297,9 @@ TEST(fft, cplx_fft_ref_vs_fft_reim_ref) {
       ASSERT_LE(d, 1e-7);
     }
     ASSERT_LE(d, 1e-7);
-    free(a);
-    free(a1);
-    free(a2);
+    spqlios_free(a);
+    spqlios_free(a1);
+    spqlios_free(a2);
     delete_cplx_fft_precomp(tables);
     delete_reim_fft_precomp(reimtables);
   }
@@ -308,9 +311,9 @@ TEST(fft, cplx_ifft_ref_vs_reim_ifft_ref) {
     uint64_t m = nn / 2;
     CPLX_IFFT_PRECOMP* tables = new_cplx_ifft_precomp(m, 0);
     REIM_IFFT_PRECOMP* reimtables = new_reim_ifft_precomp(m, 0);
-    CPLX* a = (CPLX*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    CPLX* a1 = (CPLX*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* a2 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
+    CPLX* a = (CPLX*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    CPLX* a1 = (CPLX*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* a2 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
     int64_t p = 1 << 16;
     for (uint32_t i = 0; i < nn / 2; i++) {
       a[i][0] = (rand() % p) - p / 2;  // between -p/2 and p/2
@@ -332,9 +335,9 @@ TEST(fft, cplx_ifft_ref_vs_reim_ifft_ref) {
       ASSERT_LE(d, 1e-7);
     }
     ASSERT_LE(d, 1e-7);
-    free(a);
-    free(a1);
-    free(a2);
+    spqlios_free(a);
+    spqlios_free(a1);
+    spqlios_free(a2);
     delete_cplx_fft_precomp(tables);
     delete_reim_fft_precomp(reimtables);
   }
@@ -346,12 +349,12 @@ TEST(fft, reim4_vecfft_addmul_fma_vs_ref) {
     uint64_t m = nn / 2;
     REIM4_FFTVEC_ADDMUL_PRECOMP* tbl = new_reim4_fftvec_addmul_precomp(m);
     ASSERT_TRUE(tbl != nullptr);
-    double* a1 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* a2 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* b1 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* b2 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* r1 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* r2 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
+    double* a1 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* a2 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* b1 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* b2 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* r1 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* r2 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
     int64_t p = 1 << 16;
     for (uint32_t i = 0; i < nn; i++) {
       a1[i] = (rand() % p) - p / 2;  // between -p/2 and p/2
@@ -370,12 +373,12 @@ TEST(fft, reim4_vecfft_addmul_fma_vs_ref) {
       ASSERT_LE(d, 1e-8);
     }
     ASSERT_LE(d, 1e-8);
-    free(a1);
-    free(a2);
-    free(b1);
-    free(b2);
-    free(r1);
-    free(r2);
+    spqlios_free(a1);
+    spqlios_free(a2);
+    spqlios_free(b1);
+    spqlios_free(b2);
+    spqlios_free(r1);
+    spqlios_free(r2);
     delete_reim4_fftvec_addmul_precomp(tbl);
   }
 }
@@ -386,12 +389,12 @@ TEST(fft, reim4_vecfft_mul_fma_vs_ref) {
   for (uint64_t nn : {16, 32, 64, 1024, 8192, 65536}) {
     uint64_t m = nn / 2;
     REIM4_FFTVEC_MUL_PRECOMP* tbl = new_reim4_fftvec_mul_precomp(m);
-    double* a1 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* a2 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* b1 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* b2 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* r1 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* r2 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
+    double* a1 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* a2 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* b1 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* b2 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* r1 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* r2 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
     int64_t p = 1 << 16;
     for (uint32_t i = 0; i < nn; i++) {
       a1[i] = (rand() % p) - p / 2;  // between -p/2 and p/2
@@ -410,12 +413,12 @@ TEST(fft, reim4_vecfft_mul_fma_vs_ref) {
       ASSERT_LE(d, 1e-8);
     }
     ASSERT_LE(d, 1e-8);
-    free(a1);
-    free(a2);
-    free(b1);
-    free(b2);
-    free(r1);
-    free(r2);
+    spqlios_free(a1);
+    spqlios_free(a2);
+    spqlios_free(b1);
+    spqlios_free(b2);
+    spqlios_free(r1);
+    spqlios_free(r2);
     delete_reim_fftvec_mul_precomp(tbl);
   }
 }
@@ -426,10 +429,10 @@ TEST(fft, reim4_from_cplx_fma_vs_ref) {
   for (uint64_t nn : {16, 32, 64, 1024, 8192, 65536}) {
     uint64_t m = nn / 2;
     REIM4_FROM_CPLX_PRECOMP* tbl = new_reim4_from_cplx_precomp(m);
-    double* a1 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* a2 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* r1 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* r2 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
+    double* a1 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* a2 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* r1 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* r2 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
     int64_t p = 1 << 16;
     for (uint32_t i = 0; i < nn; i++) {
       a1[i] = (rand() % p) - p / 2;  // between -p/2 and p/2
@@ -446,10 +449,10 @@ TEST(fft, reim4_from_cplx_fma_vs_ref) {
       ASSERT_LE(d, 1e-8);
     }
     ASSERT_LE(d, 1e-8);
-    free(a1);
-    free(a2);
-    free(r1);
-    free(r2);
+    spqlios_free(a1);
+    spqlios_free(a2);
+    spqlios_free(r1);
+    spqlios_free(r2);
     delete_reim4_from_cplx_precomp(tbl);
   }
 }
@@ -460,10 +463,10 @@ TEST(fft, reim4_to_cplx_fma_vs_ref) {
   for (uint64_t nn : {16, 32, 64, 1024, 8192, 65536}) {
     uint64_t m = nn / 2;
     REIM4_TO_CPLX_PRECOMP* tbl = new_reim4_to_cplx_precomp(m);
-    double* a1 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* a2 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* r1 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
-    double* r2 = (double*)aligned_alloc(32, nn / 2 * sizeof(CPLX));
+    double* a1 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* a2 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* r1 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
+    double* r2 = (double*)spqlios_alloc_custom_align(32, nn / 2 * sizeof(CPLX));
     int64_t p = 1 << 16;
     for (uint32_t i = 0; i < nn; i++) {
       a1[i] = (rand() % p) - p / 2;  // between -p/2 and p/2
@@ -480,10 +483,10 @@ TEST(fft, reim4_to_cplx_fma_vs_ref) {
       ASSERT_LE(d, 1e-8);
     }
     ASSERT_LE(d, 1e-8);
-    free(a1);
-    free(a2);
-    free(r1);
-    free(r2);
+    spqlios_free(a1);
+    spqlios_free(a2);
+    spqlios_free(r1);
+    spqlios_free(r2);
     delete_reim4_from_cplx_precomp(tbl);
   }
 }

--- a/test/spqlios_vec_znx_test.cpp
+++ b/test/spqlios_vec_znx_test.cpp
@@ -495,8 +495,12 @@ void test_vec_znx_normalize_outplace(ACTUAL_FCN test_normalize, TMP_BYTES_FNC tm
   }
 }
 
-TEST(vec_znx, vec_znx_normalize_outplace) { test_vec_znx_normalize_outplace(vec_znx_normalize_base2k, vec_znx_normalize_base2k_tmp_bytes); }
-TEST(vec_znx, vec_znx_normalize_outplace_ref) { test_vec_znx_normalize_outplace(vec_znx_normalize_base2k_ref, vec_znx_normalize_base2k_tmp_bytes_ref); }
+TEST(vec_znx, vec_znx_normalize_outplace) {
+  test_vec_znx_normalize_outplace(vec_znx_normalize_base2k, vec_znx_normalize_base2k_tmp_bytes);
+}
+TEST(vec_znx, vec_znx_normalize_outplace_ref) {
+  test_vec_znx_normalize_outplace(vec_znx_normalize_base2k_ref, vec_znx_normalize_base2k_tmp_bytes_ref);
+}
 
 template <typename ACTUAL_FCN, typename TMP_BYTES_FNC>
 void test_vec_znx_normalize_inplace(ACTUAL_FCN test_normalize, TMP_BYTES_FNC tmp_bytes) {
@@ -534,5 +538,9 @@ void test_vec_znx_normalize_inplace(ACTUAL_FCN test_normalize, TMP_BYTES_FNC tmp
   }
 }
 
-TEST(vec_znx, vec_znx_normalize_inplace) { test_vec_znx_normalize_inplace(vec_znx_normalize_base2k, vec_znx_normalize_base2k_tmp_bytes); }
-TEST(vec_znx, vec_znx_normalize_inplace_ref) { test_vec_znx_normalize_inplace(vec_znx_normalize_base2k_ref, vec_znx_normalize_base2k_tmp_bytes_ref); }
+TEST(vec_znx, vec_znx_normalize_inplace) {
+  test_vec_znx_normalize_inplace(vec_znx_normalize_base2k, vec_znx_normalize_base2k_tmp_bytes);
+}
+TEST(vec_znx, vec_znx_normalize_inplace_ref) {
+  test_vec_znx_normalize_inplace(vec_znx_normalize_base2k_ref, vec_znx_normalize_base2k_tmp_bytes_ref);
+}

--- a/test/testlib/fft64_layouts.cpp
+++ b/test/testlib/fft64_layouts.cpp
@@ -7,7 +7,7 @@ void* alloc64(uint64_t size) {
   static uint64_t _msk64 = -64;
   if (size == 0) return nullptr;
   uint64_t rsize = (size + 63) & _msk64;
-  uint8_t* reps = (uint8_t*)aligned_alloc(64, rsize);
+  uint8_t* reps = (uint8_t*)spqlios_alloc(rsize);
   REQUIRE_DRAMATICALLY(reps != 0, "Out of memory");
 #ifdef VALGRIND_MEM_TESTS
   VALGRIND_MAKE_MEM_NOACCESS(reps + size, rsize - size);
@@ -21,7 +21,7 @@ fft64_vec_znx_dft_layout::fft64_vec_znx_dft_layout(uint64_t n, uint64_t size)
       data((VEC_ZNX_DFT*)alloc64(n * size * 8)),  //
       view(n / 2, size, (double*)data) {}
 
-fft64_vec_znx_dft_layout::~fft64_vec_znx_dft_layout() { free(data); }
+fft64_vec_znx_dft_layout::~fft64_vec_znx_dft_layout() { spqlios_free(data); }
 
 double* fft64_vec_znx_dft_layout::get_addr(uint64_t idx) {
   REQUIRE_DRAMATICALLY(idx < size, "index overflow " << idx << " / " << size);
@@ -105,7 +105,7 @@ void fft64_vec_znx_big_layout::fill_random() {
     set(i, znx_i64::random_log2bound(nn, 1));
   }
 }
-fft64_vec_znx_big_layout::~fft64_vec_znx_big_layout() { free(data); }
+fft64_vec_znx_big_layout::~fft64_vec_znx_big_layout() { spqlios_free(data); }
 
 fft64_vmp_pmat_layout::fft64_vmp_pmat_layout(uint64_t n, uint64_t nrows, uint64_t ncols)
     : nn(n),
@@ -147,7 +147,7 @@ void fft64_vmp_pmat_layout::set(uint64_t row, uint64_t col, uint64_t blk, const 
   value.save_as(get_addr(row, col, blk));
 }
 
-fft64_vmp_pmat_layout::~fft64_vmp_pmat_layout() { free(data); }
+fft64_vmp_pmat_layout::~fft64_vmp_pmat_layout() { spqlios_free(data); }
 
 reim_fft64vec fft64_vmp_pmat_layout::get_zext(uint64_t row, uint64_t col) const {
   if (row >= nrows || col >= ncols) {
@@ -208,7 +208,7 @@ void fft64_svp_ppol_layout::fill_dft_random(uint64_t log2bound) { set(reim_fft64
 
 void fft64_svp_ppol_layout::fill_random(double log2bound) { set(reim_fft64vec::random(nn, log2bound)); }
 
-fft64_svp_ppol_layout::~fft64_svp_ppol_layout() { free(data); }
+fft64_svp_ppol_layout::~fft64_svp_ppol_layout() { spqlios_free(data); }
 thash fft64_svp_ppol_layout::content_hash() const { return test_hash(data, nn * sizeof(double)); }
 
 fft64_cnv_left_layout::fft64_cnv_left_layout(uint64_t n, uint64_t size)
@@ -222,7 +222,7 @@ reim4_elem fft64_cnv_left_layout::get(uint64_t idx, uint64_t blk) {
   return reim4_elem(((double*)data) + blk * size + idx);
 }
 
-fft64_cnv_left_layout::~fft64_cnv_left_layout() { free(data); }
+fft64_cnv_left_layout::~fft64_cnv_left_layout() { spqlios_free(data); }
 
 fft64_cnv_right_layout::fft64_cnv_right_layout(uint64_t n, uint64_t size)
     : nn(n),  //
@@ -235,4 +235,4 @@ reim4_elem fft64_cnv_right_layout::get(uint64_t idx, uint64_t blk) {
   return reim4_elem(((double*)data) + blk * size + idx);
 }
 
-fft64_cnv_right_layout::~fft64_cnv_right_layout() { free(data); }
+fft64_cnv_right_layout::~fft64_cnv_right_layout() { spqlios_free(data); }

--- a/test/testlib/ntt120_layouts.cpp
+++ b/test/testlib/ntt120_layouts.cpp
@@ -25,7 +25,7 @@ q120x2b* ntt120_vec_znx_dft_layout::get_blk(uint64_t idx, uint64_t blk) {
   uint64_t* d = (uint64_t*)data;
   return (q120x2b*)(d + 4 * nn * idx + 8 * blk);
 }
-ntt120_vec_znx_dft_layout::~ntt120_vec_znx_dft_layout() { free(data); }
+ntt120_vec_znx_dft_layout::~ntt120_vec_znx_dft_layout() { spqlios_free(data); }
 q120_nttvec ntt120_vec_znx_dft_layout::get_copy_zext(uint64_t idx) {
   int64_t* d = (int64_t*)data;
   if (idx < size) {
@@ -63,4 +63,4 @@ __int128* ntt120_vec_znx_big_layout::get_addr(uint64_t index) const {
   return (__int128_t*)data + index * nn;
 }
 void ntt120_vec_znx_big_layout::set(uint64_t index, const znx_i128& value) { value.save_as(get_addr(index)); }
-ntt120_vec_znx_big_layout::~ntt120_vec_znx_big_layout() { free(data); }
+ntt120_vec_znx_big_layout::~ntt120_vec_znx_big_layout() { spqlios_free(data); }


### PR DESCRIPTION
For issue: https://github.com/tfhe/spqlios-arithmetic/issues/30 (resolves #30)

in addition, made changes for:
"
In addition to the issue, ideally, we could have a _spqlios_alloc(size)  and _spqlios_free(ptr)  macros defined in common-private.h that we are going to use everywhere in new_xxx/delete_xxx functions.
On linux, in release mode, thes functions can just call  aligned_alloc  on a 64b alignment and free.
In debug mode, we can have them point to custom functions like  spqlios_debug_alloc(size) => malloc(size+64) + 64  and spqlios_debug_free(ptr) => free(ptr - 64)  that will help us track down any wrong usage.
"