### PR TITLE
spqlios-test copies its dlls

### DIFF
--- a/.github/workflows/cmake-build-test-win64.yml
+++ b/.github/workflows/cmake-build-test-win64.yml
@@ -32,7 +32,8 @@ jobs:
       run: cmake --build build
 
     - name: Test
-      run: cd build; cp -v ./spqlios/*.dll test/; ctest --output-on-failure
+      working-directory: build
+      run: ctest --output-on-failure
     
     - name: CI Package
       if: github.event_name != 'pull_request'

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -90,7 +90,17 @@ add_executable(spqlios-test ${UNITTEST_FILES})
 target_link_libraries(spqlios-test spqlios-testlib libspqlios ${gtest_libs})
 target_include_directories(spqlios-test PRIVATE ${test_incs})
 add_test(NAME spqlios-test COMMAND spqlios-test)
-
+if (WIN32)
+    # copy the dlls to the test directory
+    cmake_minimum_required(VERSION 3.26)
+    add_custom_command(
+            POST_BUILD
+            TARGET spqlios-test
+            COMMAND ${CMAKE_COMMAND} -E copy
+            -t $<TARGET_FILE_DIR:spqlios-test> $<TARGET_RUNTIME_DLLS:spqlios-testlib> $<TARGET_RUNTIME_DLLS:libspqlios>
+            COMMAND_EXPAND_LISTS
+    )
+endif()
 
 # benchmarks
 add_executable(spqlios-cplx-fft-bench spqlios_cplx_fft_bench.cpp)


### PR DESCRIPTION
spqlios-test copies its required dlls in the test folder (to avoid the ci bug when added as a submodule)