### PR TITLE
Small fixes needed to support both znx and rnx arithmetic

### DIFF
--- a/spqlios/coeffs/coeffs_arithmetic.c
+++ b/spqlios/coeffs/coeffs_arithmetic.c
@@ -25,6 +25,13 @@ EXPORT void znx_copy_i64_ref(uint64_t nn, int64_t* res, const int64_t* a) { memc
 
 EXPORT void znx_zero_i64_ref(uint64_t nn, int64_t* res) { memset(res, 0, nn * sizeof(int64_t)); }
 
+EXPORT void rnx_divide_by_m_ref(uint64_t n, double m, double* res, const double* a) {
+  const double invm = 1. / m;
+  for (uint64_t i = 0; i < n; ++i) {
+    res[i] = a[i] * invm;
+  }
+}
+
 EXPORT void rnx_rotate_f64(uint64_t nn, int64_t p, double* res, const double* in) {
   uint64_t a = (-p) & (2 * nn - 1);  // a= (-p) (pos)mod (2*nn)
 

--- a/spqlios/coeffs/coeffs_arithmetic.h
+++ b/spqlios/coeffs/coeffs_arithmetic.h
@@ -17,6 +17,10 @@ EXPORT void znx_copy_i64_ref(uint64_t nn, int64_t* res, const int64_t* a);
 /** res = 0 */
 EXPORT void znx_zero_i64_ref(uint64_t nn, int64_t* res);
 
+/** res = a / m where m is a power of 2 */
+EXPORT void rnx_divide_by_m_ref(uint64_t nn, double m, double* res, const double* a);
+EXPORT void rnx_divide_by_m_avx(uint64_t nn, double m, double* res, const double* a);
+
 /**
  * @param res = X^p *in mod X^nn +1
  * @param nn the ring dimension

--- a/spqlios/reim4/reim4_arithmetic.h
+++ b/spqlios/reim4/reim4_arithmetic.h
@@ -89,6 +89,20 @@ EXPORT void reim4_extract_1blk_from_contiguous_reim_avx(uint64_t m, uint64_t nro
                                                         const double* const src);
 
 /**
+ * @brief extract 1 reim4 block from nrows reim vectors of m complexes with slice sl
+ * @param m the size of each reim
+ * @param sl the slice size
+ * @param nrows the number of reim (fft) vectors to extract
+ * @param blk the block id to extract (<m/4)
+ * @param dst the output: nrows reim4's  dst[i] = src[i](blk)
+ * @param src the input: nrows reim's
+ */
+EXPORT void reim4_extract_1blk_from_contiguous_reim_sl_ref(uint64_t m, uint64_t sl, uint64_t nrows, uint64_t blk,
+                                                           double* const dst, const double* const src);
+EXPORT void reim4_extract_1blk_from_contiguous_reim_sl_avx(uint64_t m, uint64_t sl, uint64_t nrows, uint64_t blk,
+                                                           double* const dst, const double* const src);
+
+/**
  * @brief saves 1 single reim4 block in a reim vectors of m complexes
  * @param m the size of each reim
  * @param blk the block id to save (<m/4)

--- a/spqlios/reim4/reim4_arithmetic_avx2.c
+++ b/spqlios/reim4/reim4_arithmetic_avx2.c
@@ -26,6 +26,19 @@ void reim4_extract_1blk_from_contiguous_reim_avx(uint64_t m, uint64_t nrows, uin
   }
 }
 
+EXPORT void reim4_extract_1blk_from_contiguous_reim_sl_avx(uint64_t m, uint64_t sl, uint64_t nrows, uint64_t blk,
+                                                           double* const dst, const double* const src) {
+  assert(blk < (m >> 2));
+  const double* src_ptr = src + (blk << 2);
+  double* dst_ptr = dst;
+  for (uint64_t i = 0; i < nrows; ++i) {
+    _mm256_storeu_pd(dst_ptr, _mm256_loadu_pd(src_ptr));
+    _mm256_storeu_pd(dst_ptr + 4, _mm256_loadu_pd(src_ptr + m));
+    dst_ptr += 8;
+    src_ptr += sl;
+  }
+}
+
 void reim4_save_1blk_to_reim_avx(uint64_t m, uint64_t blk,
                                  double* dst,       // 1 reim vector of length m
                                  const double* src  // 8 doubles

--- a/spqlios/reim4/reim4_arithmetic_ref.c
+++ b/spqlios/reim4/reim4_arithmetic_ref.c
@@ -38,6 +38,29 @@ EXPORT void reim4_extract_1blk_from_contiguous_reim_ref(uint64_t m, uint64_t nro
   }
 }
 
+EXPORT void reim4_extract_1blk_from_contiguous_reim_sl_ref(uint64_t m, uint64_t sl, uint64_t nrows, uint64_t blk,
+                                                           double* const dst, const double* const src) {
+  assert(blk < (m >> 2));
+
+  const double* src_ptr = src + (blk << 2);
+  double* dst_ptr = dst;
+  const uint64_t sl_minus_m = sl - m;
+  for (uint64_t i = 0; i < nrows; ++i) {
+    dst_ptr[0] = src_ptr[0];
+    dst_ptr[1] = src_ptr[1];
+    dst_ptr[2] = src_ptr[2];
+    dst_ptr[3] = src_ptr[3];
+    dst_ptr += 4;
+    src_ptr += m;
+    dst_ptr[0] = src_ptr[0];
+    dst_ptr[1] = src_ptr[1];
+    dst_ptr[2] = src_ptr[2];
+    dst_ptr[3] = src_ptr[3];
+    dst_ptr += 4;
+    src_ptr += sl_minus_m;
+  }
+}
+
 // dest(i)=src
 // use scalar or sse or avx? Code
 // should be the inverse of reim4_extract_1col_from_reim

--- a/test/spqlios_vmp_product_test.cpp
+++ b/test/spqlios_vmp_product_test.cpp
@@ -86,7 +86,7 @@ static void test_vmp_apply(VMP_APPLY_DFT_TO_DFT_F* apply, VMP_APPLY_DFT_TO_DFT_T
             in.fill_random(0);
             pmat.fill_random(0);
             // naive computation of the product
-            std::vector<reim_fft64vec> expect(out_size, nn);
+            std::vector<reim_fft64vec> expect(out_size, reim_fft64vec(nn));
             for (uint64_t col = 0; col < out_size; ++col) {
               reim_fft64vec ex = reim_fft64vec::zero(nn);
               for (uint64_t row = 0; row < std::min(mat_nrows, in_size); ++row) {

--- a/test/testlib/fft64_dft.cpp
+++ b/test/testlib/fft64_dft.cpp
@@ -137,3 +137,32 @@ double infty_dist(const reim_fft64vec& a, const reim_fft64vec& b) {
   }
   return d;
 }
+
+reim_fft64vec simple_fft64(const rnx_f64& polynomial) {
+  const uint64_t nn = polynomial.nn();
+  const uint64_t m = nn / 2;
+  reim_fft64vec res(nn);
+  double* dat = res.data();
+  for (uint64_t i = 0; i < nn; ++i) dat[i] = polynomial.get_coeff(i);
+  reim_fft_simple(m, dat);
+  return res;
+}
+
+reim_fft64vec operator*(double coeff, const reim_fft64vec& v) {
+  const uint64_t nn = v.nn();
+  reim_fft64vec res(nn);
+  double* rr = res.data();
+  const double* vv = v.data();
+  for (uint64_t i = 0; i < nn; ++i) rr[i] = coeff * vv[i];
+  return res;
+}
+
+rnx_f64 simple_ifft64(const reim_fft64vec& v) {
+  const uint64_t nn = v.nn();
+  const uint64_t m = nn / 2;
+  rnx_f64 res(nn);
+  double* dat = res.data();
+  memcpy(dat, v.data(), nn * sizeof(double));
+  reim_ifft_simple(m, dat);
+  return res;
+}

--- a/test/testlib/fft64_dft.h
+++ b/test/testlib/fft64_dft.h
@@ -9,7 +9,7 @@ class reim_fft64vec {
 
  public:
   reim_fft64vec() = default;
-  reim_fft64vec(uint64_t n);
+  explicit reim_fft64vec(uint64_t n);
   reim_fft64vec(uint64_t n, const double* data);
   uint64_t nn() const;
   static reim_fft64vec zero(uint64_t n);
@@ -27,6 +27,7 @@ class reim_fft64vec {
 reim_fft64vec operator+(const reim_fft64vec& a, const reim_fft64vec& b);
 reim_fft64vec operator-(const reim_fft64vec& a, const reim_fft64vec& b);
 reim_fft64vec operator*(const reim_fft64vec& a, const reim_fft64vec& b);
+reim_fft64vec operator*(double coeff, const reim_fft64vec& v);
 reim_fft64vec& operator+=(reim_fft64vec& a, const reim_fft64vec& b);
 reim_fft64vec& operator-=(reim_fft64vec& a, const reim_fft64vec& b);
 
@@ -36,5 +37,7 @@ double infty_dist(const reim_fft64vec& a, const reim_fft64vec& b);
 reim_fft64vec simple_fft64(const znx_i64& polynomial);
 znx_i64 simple_rint_ifft64(const reim_fft64vec& fftvec);
 rnx_f64 naive_ifft64(const reim_fft64vec& fftvec);
+reim_fft64vec simple_fft64(const rnx_f64& polynomial);
+rnx_f64 simple_ifft64(const reim_fft64vec& v);
 
 #endif  // SPQLIOS_FFT64_DFT_H

--- a/test/testlib/negacyclic_polynomial.cpp
+++ b/test/testlib/negacyclic_polynomial.cpp
@@ -4,3 +4,15 @@
 EXPLICIT_INSTANTIATE_POLYNOMIAL(__int128_t);
 EXPLICIT_INSTANTIATE_POLYNOMIAL(int64_t);
 EXPLICIT_INSTANTIATE_POLYNOMIAL(double);
+
+double infty_dist(const rnx_f64& a, const rnx_f64& b) {
+  const uint64_t nn = a.nn();
+  const double* aa = a.data();
+  const double* bb = b.data();
+  double res = 0.;
+  for (uint64_t i = 0; i < nn; ++i) {
+    double d = fabs(aa[i] - bb[i]);
+    if (d > res) res = d;
+  }
+  return res;
+}

--- a/test/testlib/negacyclic_polynomial.h
+++ b/test/testlib/negacyclic_polynomial.h
@@ -63,4 +63,7 @@ polynomial<T> operator-(const polynomial<T>& a);
 template <typename T>
 polynomial<T> naive_product(const polynomial<T>& a, const polynomial<T>& b);
 
+/** @brief distance between two real polynomials (used during tests) */
+double infty_dist(const rnx_f64& a, const rnx_f64& b);
+
 #endif  // SPQLIOS_NEGACYCLIC_POLYNOMIAL_H

--- a/test/testlib/ntt120_dft.h
+++ b/test/testlib/ntt120_dft.h
@@ -12,7 +12,7 @@ class q120_nttvec {
  public:
   std::vector<mod_q120> v;
   q120_nttvec() = default;
-  q120_nttvec(uint64_t n);
+  explicit q120_nttvec(uint64_t n);
   q120_nttvec(uint64_t n, const q120b* data);
   q120_nttvec(uint64_t n, const q120c* data);
   uint64_t nn() const;

--- a/test/testlib/ntt120_layouts.h
+++ b/test/testlib/ntt120_layouts.h
@@ -14,8 +14,8 @@ struct mod_q120x2 {
   mod_q120x2();
   mod_q120x2(const mod_q120& a, const mod_q120& b);
   mod_q120x2(__int128_t value);
-  mod_q120x2(q120x2b* addr);
-  mod_q120x2(q120x2c* addr);
+  explicit mod_q120x2(q120x2b* addr);
+  explicit mod_q120x2(q120x2c* addr);
   void save_as(q120x2b* addr) const;
   void save_as(q120x2c* addr) const;
   static mod_q120x2 random();

--- a/test/testlib/reim4_elem.h
+++ b/test/testlib/reim4_elem.h
@@ -11,7 +11,7 @@ class reim4_elem {
   /** @brief constructs from 4 real parts and 4 imaginary parts */
   reim4_elem(const double* re, const double* im);
   /** @brief constructs from 8 components */
-  reim4_elem(const double* layout);
+  explicit reim4_elem(const double* layout);
   /** @brief zero */
   reim4_elem();
   /** @brief saves the real parts to re and the 4 imag to im */


### PR DESCRIPTION
- made some test constructors explicit to avoid unwanted behaviour
- added some missing test fft/ifft with real coefficients
- added the division by m on coeffs arithmetic
- slice support in reim4 low-level arithmetic.