### PR TITLE
Convolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 cmake-build-*
 .idea
+.clangd
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
 project(spqlios)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # read the current version from the manifest file
 file(READ "manifest.yaml" manifest)
 string(REGEX MATCH "version: +(([0-9]+)\\.([0-9]+)\\.([0-9]+))" SPQLIOS_VERSION_BLAH ${manifest})

--- a/spqlios/CMakeLists.txt
+++ b/spqlios/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SRCS_GENERIC
         arithmetic/vec_znx.c
         arithmetic/vec_znx_dft.c
         arithmetic/vector_matrix_product.c
+        arithmetic/vec_znx_convolution.c
         cplx/cplx_common.c
         cplx/cplx_conversions.c
         cplx/cplx_fft_asserts.c

--- a/spqlios/arithmetic/module_api.c
+++ b/spqlios/arithmetic/module_api.c
@@ -51,6 +51,7 @@ static void fill_fft64_virtual_table(MODULE* module) {
   module->func.vmp_apply_dft_tmp_bytes = fft64_vmp_apply_dft_tmp_bytes;
   module->func.vmp_apply_dft_to_dft = fft64_vmp_apply_dft_to_dft_ref;
   module->func.vmp_apply_dft_to_dft_tmp_bytes = fft64_vmp_apply_dft_to_dft_tmp_bytes;
+  module->func.cnv_prepare_right_contiguous = fft64_convolution_prepare_right_contiguous_ref;
   module->func.bytes_of_vec_znx_dft = fft64_bytes_of_vec_znx_dft;
   module->func.bytes_of_vec_znx_dft = fft64_bytes_of_vec_znx_dft;
   module->func.bytes_of_vec_znx_dft = fft64_bytes_of_vec_znx_dft;

--- a/spqlios/arithmetic/module_api.c
+++ b/spqlios/arithmetic/module_api.c
@@ -51,7 +51,12 @@ static void fill_fft64_virtual_table(MODULE* module) {
   module->func.vmp_apply_dft_tmp_bytes = fft64_vmp_apply_dft_tmp_bytes;
   module->func.vmp_apply_dft_to_dft = fft64_vmp_apply_dft_to_dft_ref;
   module->func.vmp_apply_dft_to_dft_tmp_bytes = fft64_vmp_apply_dft_to_dft_tmp_bytes;
+  module->func.cnv_prepare_right_contiguous_tmp_bytes = fft64_convolution_prepare_right_contiguous_tmp_bytes;
+  module->func.cnv_prepare_left_contiguous_tmp_bytes = fft64_convolution_prepare_left_contiguous_tmp_bytes;
   module->func.cnv_prepare_right_contiguous = fft64_convolution_prepare_right_contiguous_ref;
+  module->func.cnv_prepare_left_contiguous = fft64_convolution_prepare_left_contiguous_ref;
+  module->func.cnv_apply_dft = fft64_convolution_apply_dft_ref;
+  module->func.cnv_apply_dft_tmp_bytes = fft64_convolution_apply_dft_tmp_bytes;
   module->func.bytes_of_vec_znx_dft = fft64_bytes_of_vec_znx_dft;
   module->func.bytes_of_vec_znx_dft = fft64_bytes_of_vec_znx_dft;
   module->func.bytes_of_vec_znx_dft = fft64_bytes_of_vec_znx_dft;

--- a/spqlios/arithmetic/vec_znx_arithmetic.h
+++ b/spqlios/arithmetic/vec_znx_arithmetic.h
@@ -354,4 +354,43 @@ EXPORT uint64_t vmp_apply_dft_to_dft_tmp_bytes(const MODULE* module,           /
                                                uint64_t a_size,                // a
                                                uint64_t nrows, uint64_t ncols  // prep matrix
 );
+
+/** @brief prepares the right vector for convolution  */
+EXPORT void cnv_prepare_right_contiguous(const MODULE* module,                              // N
+                                         CNV_PVEC_R* pvec, uint64_t nrows,                  // output
+                                         const int64_t* a, uint64_t a_size, uint64_t a_sl,  // a
+                                         uint8_t* tmp_space                                 // scratch space
+);
+
+/** @brief minimal scratch space byte-size required for the cnv_prepare_right_contiguous function */
+EXPORT uint64_t cnv_prepare_right_contiguous_tmp_bytes(const MODULE* module,  // N
+                                                       uint64_t nrows);
+
+/** @brief prepares the right vector for convolution  */
+EXPORT void cnv_prepare_left_contiguous(const MODULE* module,                              // N
+                                        CNV_PVEC_L* pvec, uint64_t nrows,                  // output
+                                        const int64_t* a, uint64_t a_size, uint64_t a_sl,  // a
+                                        uint8_t* tmp_space                                 // scratch space
+);
+
+/** @brief minimal scratch space byte-size required for the cnv_prepare_left_contiguous function */
+EXPORT uint64_t cnv_prepare_left_contiguous_tmp_bytes(const MODULE* module,  // N
+                                                      uint64_t nrows);
+
+/** @brief applies a convolution of two prepared vectors  */
+EXPORT void cnv_apply_dft(const MODULE* module,                                      // N
+                          VEC_ZNX_DFT* res, uint64_t res_size, uint64_t res_offset,  // output
+                          const CNV_PVEC_L* a,
+                          uint64_t a_size,  // left operand and its size (in terms of reim4)
+                          const CNV_PVEC_R* b,
+                          uint64_t b_size,    // right operand and its size (in terms of reim4)
+                          uint8_t* tmp_space  // scratch space
+);
+
+/** @brief minimal scratch space byte-size required for the cnv_apply_dft function */
+EXPORT uint64_t cnv_apply_dft_tmp_bytes(const MODULE* module,                    // N
+                                        uint64_t res_size, uint64_t res_offset,  // output
+                                        uint64_t a_size,                         // size of left operand
+                                        uint64_t b_size                          // size of right operand
+);
 #endif  // SPQLIOS_VEC_ZNX_ARITHMETIC_H

--- a/spqlios/arithmetic/vec_znx_arithmetic.h
+++ b/spqlios/arithmetic/vec_znx_arithmetic.h
@@ -364,7 +364,9 @@ EXPORT void cnv_prepare_right_contiguous(const MODULE* module,                  
 
 /** @brief minimal scratch space byte-size required for the cnv_prepare_right_contiguous function */
 EXPORT uint64_t cnv_prepare_right_contiguous_tmp_bytes(const MODULE* module,  // N
-                                                       uint64_t nrows);
+                                                       uint64_t nrows,        // size of output
+                                                       uint64_t a_size        // size of input
+);
 
 /** @brief prepares the right vector for convolution  */
 EXPORT void cnv_prepare_left_contiguous(const MODULE* module,                              // N
@@ -375,7 +377,9 @@ EXPORT void cnv_prepare_left_contiguous(const MODULE* module,                   
 
 /** @brief minimal scratch space byte-size required for the cnv_prepare_left_contiguous function */
 EXPORT uint64_t cnv_prepare_left_contiguous_tmp_bytes(const MODULE* module,  // N
-                                                      uint64_t nrows);
+                                                      uint64_t nrows,        // size of output
+                                                      uint64_t a_size        // size of input
+);
 
 /** @brief applies a convolution of two prepared vectors  */
 EXPORT void cnv_apply_dft(const MODULE* module,                                      // N

--- a/spqlios/arithmetic/vec_znx_arithmetic_private.h
+++ b/spqlios/arithmetic/vec_znx_arithmetic_private.h
@@ -434,11 +434,15 @@ EXPORT void fft64_convolution_prepare_right_contiguous_ref(const MODULE* module,
 
 /** @brief minimal scratch space byte-size required for the cnv_prepare_right_contiguous function */
 EXPORT uint64_t fft64_convolution_prepare_right_contiguous_tmp_bytes(const MODULE* module,  // N
-                                                                     uint64_t nrows);
+                                                                     uint64_t nrows,        // size of output
+                                                                     uint64_t a_size        // size of input
+);
 
 /** @brief minimal scratch space byte-size required for the cnv_prepare_left_contiguous function */
 EXPORT uint64_t fft64_convolution_prepare_left_contiguous_tmp_bytes(const MODULE* module,  // N
-                                                                    uint64_t nrows);
+                                                                    uint64_t nrows,        // size of output
+                                                                    uint64_t a_size        // size of input
+);
 
 /** @brief prepares the left vector for convolution  */
 EXPORT void fft64_convolution_prepare_left_contiguous_ref(const MODULE* module,                              // N

--- a/spqlios/arithmetic/vec_znx_arithmetic_private.h
+++ b/spqlios/arithmetic/vec_znx_arithmetic_private.h
@@ -413,6 +413,26 @@ EXPORT void fft64_znx_small_single_product(const MODULE* module,  // N
 /** @brief tmp bytes required for znx_small_single_product  */
 EXPORT uint64_t fft64_znx_small_single_product_tmp_bytes(const MODULE* module);
 
+/** @brief prepares the right vector for convolution  */
+EXPORT void fft64_convolution_prepare_right_contiguous_ref(const MODULE* module,                              // N
+                                                           CNV_PVEC_R* pvec, uint64_t nrows,                  // output
+                                                           const int64_t* a, uint64_t a_size, uint64_t a_sl,  // a
+                                                           uint8_t* tmp_space  // scratch space
+);
+
+/** @brief prepares the left vector for convolution  */
+EXPORT void fft64_convolution_prepare_left_contiguous_ref(const MODULE* module,                              // N
+                                                          CNV_PVEC_L* pvec, uint64_t nrows,                  // output
+                                                          const int64_t* a, uint64_t a_size, uint64_t a_sl,  // a
+                                                          uint8_t* tmp_space  // scratch space
+);
+
+/** @brief prepares a convolution vector  */
+EXPORT void fft64_convolution_prepare_contiguous_ref(const MODULE* module,                              // N
+                                                     double* pvec, uint64_t nrows,                      // output
+                                                     const int64_t* a, uint64_t a_size, uint64_t a_sl,  // a
+                                                     uint8_t* tmp_space                                 // scratch space
+);
 /** @brief prepares a vmp matrix (contiguous row-major version) */
 EXPORT void fft64_vmp_prepare_contiguous_ref(const MODULE* module,                                // N
                                              VMP_PMAT* pmat,                                      // output

--- a/spqlios/arithmetic/vec_znx_arithmetic_private.h
+++ b/spqlios/arithmetic/vec_znx_arithmetic_private.h
@@ -85,6 +85,12 @@ typedef typeof(znx_small_single_product) ZNX_SMALL_SINGLE_PRODUCT_F;
 typedef typeof(znx_small_single_product_tmp_bytes) ZNX_SMALL_SINGLE_PRODUCT_TMP_BYTES_F;
 typedef typeof(vmp_prepare_contiguous) VMP_PREPARE_CONTIGUOUS_F;
 typedef typeof(vmp_prepare_contiguous_tmp_bytes) VMP_PREPARE_CONTIGUOUS_TMP_BYTES_F;
+typedef typeof(cnv_apply_dft) CNV_APPLY_DFT_F;
+typedef typeof(cnv_apply_dft_tmp_bytes) CNV_APPLY_DFT_TMP_BYTES_F;
+typedef typeof(cnv_prepare_left_contiguous) CNV_PREPARE_LEFT_CONTIGUOUS_F;
+typedef typeof(cnv_prepare_left_contiguous_tmp_bytes) CNV_PREPARE_LEFT_CONTIGUOUS_TMP_BYTES_F;
+typedef typeof(cnv_prepare_right_contiguous) CNV_PREPARE_RIGHT_CONTIGUOUS_F;
+typedef typeof(cnv_prepare_right_contiguous_tmp_bytes) CNV_PREPARE_RIGHT_CONTIGUOUS_TMP_BYTES_F;
 typedef typeof(vmp_apply_dft) VMP_APPLY_DFT_F;
 typedef typeof(vmp_apply_dft_tmp_bytes) VMP_APPLY_DFT_TMP_BYTES_F;
 typedef typeof(vmp_apply_dft_to_dft) VMP_APPLY_DFT_TO_DFT_F;
@@ -132,6 +138,12 @@ struct module_virtual_functions_t {
   VMP_APPLY_DFT_TMP_BYTES_F* vmp_apply_dft_tmp_bytes;
   VMP_APPLY_DFT_TO_DFT_F* vmp_apply_dft_to_dft;
   VMP_APPLY_DFT_TO_DFT_TMP_BYTES_F* vmp_apply_dft_to_dft_tmp_bytes;
+  CNV_APPLY_DFT_F* cnv_apply_dft;
+  CNV_APPLY_DFT_TMP_BYTES_F* cnv_apply_dft_tmp_bytes;
+  CNV_PREPARE_LEFT_CONTIGUOUS_F* cnv_prepare_left_contiguous;
+  CNV_PREPARE_LEFT_CONTIGUOUS_TMP_BYTES_F* cnv_prepare_left_contiguous_tmp_bytes;
+  CNV_PREPARE_RIGHT_CONTIGUOUS_F* cnv_prepare_right_contiguous;
+  CNV_PREPARE_RIGHT_CONTIGUOUS_TMP_BYTES_F* cnv_prepare_right_contiguous_tmp_bytes;
   BYTES_OF_VEC_ZNX_DFT_F* bytes_of_vec_znx_dft;
   BYTES_OF_VEC_ZNX_BIG_F* bytes_of_vec_znx_big;
   BYTES_OF_SVP_PPOL_F* bytes_of_svp_ppol;
@@ -420,6 +432,14 @@ EXPORT void fft64_convolution_prepare_right_contiguous_ref(const MODULE* module,
                                                            uint8_t* tmp_space  // scratch space
 );
 
+/** @brief minimal scratch space byte-size required for the cnv_prepare_right_contiguous function */
+EXPORT uint64_t fft64_convolution_prepare_right_contiguous_tmp_bytes(const MODULE* module,  // N
+                                                                     uint64_t nrows);
+
+/** @brief minimal scratch space byte-size required for the cnv_prepare_left_contiguous function */
+EXPORT uint64_t fft64_convolution_prepare_left_contiguous_tmp_bytes(const MODULE* module,  // N
+                                                                    uint64_t nrows);
+
 /** @brief prepares the left vector for convolution  */
 EXPORT void fft64_convolution_prepare_left_contiguous_ref(const MODULE* module,                              // N
                                                           CNV_PVEC_L* pvec, uint64_t nrows,                  // output
@@ -433,6 +453,23 @@ EXPORT void fft64_convolution_prepare_contiguous_ref(const MODULE* module,      
                                                      const int64_t* a, uint64_t a_size, uint64_t a_sl,  // a
                                                      uint8_t* tmp_space                                 // scratch space
 );
+
+EXPORT uint64_t fft64_convolution_apply_dft_tmp_bytes(const MODULE* module,                    // N
+                                                      uint64_t res_size, uint64_t res_offset,  // output
+                                                      uint64_t a_size,  // size of left operand (in terms of reim4)
+                                                      uint64_t b_size   // size of right operand (in terms of reim4)
+);
+
+/** @brief applies a convolution of two prepared vectors  */
+EXPORT void fft64_convolution_apply_dft_ref(const MODULE* module,                                      // N
+                                            VEC_ZNX_DFT* res, uint64_t res_size, uint64_t res_offset,  // output
+                                            const CNV_PVEC_L* a,
+                                            uint64_t a_size,  // left operand and its size (in terms of reim4)
+                                            const CNV_PVEC_R* b,
+                                            uint64_t b_size,    // right operand and its size (in terms of reim4)
+                                            uint8_t* tmp_space  // scratch space
+);
+
 /** @brief prepares a vmp matrix (contiguous row-major version) */
 EXPORT void fft64_vmp_prepare_contiguous_ref(const MODULE* module,                                // N
                                              VMP_PMAT* pmat,                                      // output

--- a/spqlios/arithmetic/vec_znx_convolution.c
+++ b/spqlios/arithmetic/vec_znx_convolution.c
@@ -83,6 +83,10 @@ EXPORT void fft64_convolution_prepare_contiguous_ref(const MODULE* module,      
 ) {
   const uint64_t m = module->m;
   const uint64_t rows = nrows < a_size ? nrows : a_size;
+  // dimensions where m < 4 are not implemented yet
+  if (m<4) {
+    NOT_IMPLEMENTED()
+  }
 
   VEC_ZNX_DFT* a_dft = (VEC_ZNX_DFT*)tmp_space;
 

--- a/spqlios/arithmetic/vec_znx_convolution.c
+++ b/spqlios/arithmetic/vec_znx_convolution.c
@@ -53,7 +53,7 @@ EXPORT uint64_t fft64_convolution_prepare_left_contiguous_tmp_bytes(const MODULE
 ) {
   const uint64_t nn = module->nn;
   const uint64_t rows = nrows < a_size ? nrows : a_size;
-  return nn * sizeof(int64_t) * rows;
+  return nn * sizeof(double) * rows;
 }
 
 /** @brief minimal scratch space byte-size required for the cnv_prepare_right_contiguous function */

--- a/spqlios/arithmetic/vec_znx_convolution.c
+++ b/spqlios/arithmetic/vec_znx_convolution.c
@@ -1,0 +1,142 @@
+#include <string.h>
+
+#include "../reim4/reim4_arithmetic.h"
+#include "vec_znx_arithmetic_private.h"
+
+/** @brief prepares the right vector for convolution  */
+EXPORT void cnv_prepare_right_contiguous(const MODULE* module,                              // N
+                                         CNV_PVEC_R* pvec, uint64_t nrows,                  // output
+                                         const int64_t* a, uint64_t a_size, uint64_t a_sl,  // a
+                                         uint8_t* tmp_space                                 // scratch space
+) {
+  return module->func.cnv_prepare_right_contiguous(module, pvec, nrows, a, a_size, a_sl, tmp_space);
+}
+
+/** @brief minimal scratch space byte-size required for the cnv_prepare_right_contiguous function */
+EXPORT uint64_t cnv_prepare_right_contiguous_tmp_bytes(const MODULE* module,  // N
+                                                       uint64_t nrows) {
+  return module->func.cnv_prepare_right_contiguous_tmp_bytes(module, nrows);
+}
+
+/** @brief prepares the right vector for convolution  */
+EXPORT void cnv_prepare_left_contiguous(const MODULE* module,                              // N
+                                        CNV_PVEC_L* pvec, uint64_t nrows,                  // output
+                                        const int64_t* a, uint64_t a_size, uint64_t a_sl,  // a
+                                        uint8_t* tmp_space                                 // scratch space
+) {
+  return module->func.cnv_prepare_left_contiguous(module, pvec, nrows, a, a_size, a_sl, tmp_space);
+}
+
+/** @brief minimal scratch space byte-size required for the cnv_prepare_left_contiguous function */
+EXPORT uint64_t cnv_prepare_left_contiguous_tmp_bytes(const MODULE* module,  // N
+                                                      uint64_t nrows) {
+  return module->func.cnv_prepare_left_contiguous_tmp_bytes(module, nrows);
+}
+
+/** @brief prepares the right vector for convolution  */
+EXPORT void fft64_convolution_prepare_right_contiguous_ref(const MODULE* module,                              // N
+                                                           CNV_PVEC_R* pvec, uint64_t nrows,                  // output
+                                                           const int64_t* a, uint64_t a_size, uint64_t a_sl,  // a
+                                                           uint8_t* tmp_space  // scratch space
+) {
+  fft64_convolution_prepare_contiguous_ref(module, (double*)pvec, nrows, a, a_size, a_sl, tmp_space);
+}
+
+/** @brief minimal scratch space byte-size required for the cnv_prepare_left_contiguous function */
+EXPORT uint64_t fft64_convolution_prepare_left_contiguous_tmp_bytes(const MODULE* module,  // N
+                                                                    uint64_t nrows) {
+  const uint64_t nn = module->nn;
+  return nn * sizeof(int64_t) * nrows;
+}
+
+/** @brief minimal scratch space byte-size required for the cnv_prepare_right_contiguous function */
+EXPORT uint64_t fft64_convolution_prepare_right_contiguous_tmp_bytes(const MODULE* module,  // N
+                                                                     uint64_t nrows) {
+  const uint64_t nn = module->nn;
+  return nn * sizeof(uint64_t) * nrows;
+}
+
+/** @brief prepares the left vector for convolution  */
+EXPORT void fft64_convolution_prepare_left_contiguous_ref(const MODULE* module,                              // N
+                                                          CNV_PVEC_L* pvec, uint64_t nrows,                  // output
+                                                          const int64_t* a, uint64_t a_size, uint64_t a_sl,  // a
+                                                          uint8_t* tmp_space  // scratch space
+) {
+  fft64_convolution_prepare_contiguous_ref(module, (double*)pvec, nrows, a, a_size, a_sl, tmp_space);
+}
+
+/** @brief prepares a convolution vector  */
+EXPORT void fft64_convolution_prepare_contiguous_ref(const MODULE* module,                              // N
+                                                     double* pvec, uint64_t nrows,                      // output
+                                                     const int64_t* a, uint64_t a_size, uint64_t a_sl,  // a
+                                                     uint8_t* tmp_space                                 // scratch space
+) {
+  const uint64_t m = module->m;
+  const uint64_t rows = nrows < a_size ? nrows : a_size;
+
+  VEC_ZNX_DFT* a_dft = (VEC_ZNX_DFT*)tmp_space;
+
+  fft64_vec_znx_dft(module, a_dft, rows, a, a_size, a_sl);
+
+  for (uint64_t blk_i = 0; blk_i < m / 4; blk_i++) {
+    reim4_extract_1blk_from_contiguous_reim_ref(m, rows, blk_i, pvec + blk_i * rows * 8, (const double*)a_dft);
+  }
+}
+
+/** @brief applies a convolution of two prepared vectors  */
+EXPORT void cnv_apply_dft(const MODULE* module,                                      // N
+                          VEC_ZNX_DFT* res, uint64_t res_size, uint64_t res_offset,  // output
+                          const CNV_PVEC_L* a,
+                          uint64_t a_size,  // left operand and its size (in terms of reim4)
+                          const CNV_PVEC_R* b,
+                          uint64_t b_size,    // right operand and its size (in terms of reim4)
+                          uint8_t* tmp_space  // scratch space
+) {
+  return module->func.cnv_apply_dft(module, res, res_size, res_offset, a, a_size, b, b_size, tmp_space);
+}
+
+/** @brief minimal scratch space byte-size required for the cnv_apply_dft function */
+EXPORT uint64_t cnv_apply_dft_tmp_bytes(const MODULE* module,                    // N
+                                        uint64_t res_size, uint64_t res_offset,  // output
+                                        uint64_t a_size,                         // size of left operand
+                                        uint64_t b_size                          // size of right operand
+) {
+  return module->func.cnv_apply_dft_tmp_bytes(module, res_size, res_offset, a_size, b_size);
+}
+
+/** @brief applies a convolution of two prepared vectors  */
+EXPORT void fft64_convolution_apply_dft_ref(const MODULE* module,                                      // N
+                                            VEC_ZNX_DFT* res, uint64_t res_size, uint64_t res_offset,  // output
+                                            const CNV_PVEC_L* a,
+                                            uint64_t a_size,  // left operand and its size (in terms of reim4)
+                                            const CNV_PVEC_R* b,
+                                            uint64_t b_size,    // right operand and its size (in terms of reim4)
+                                            uint8_t* tmp_space  // scratch space
+) {
+  const uint64_t m = module->m;
+  const uint64_t nn = module->nn;
+  uint64_t size = res_size < a_size + b_size - 1 ? res_size : a_size + b_size - 1;
+  uint64_t offset = res_offset < size ? res_offset : size;
+
+  double* dst_tmp = (double*)tmp_space;
+  double* dst = (double*)res;
+  const double* a_double = (const double*)a;
+  const double* b_double = (const double*)b;
+
+  for (uint64_t blk_i = 0; blk_i < m / 4; blk_i++) {
+    reim4_convolution_ref(dst_tmp, size, offset, a_double + blk_i * a_size * 8, a_size, b_double + blk_i * b_size * 8,
+                          b_size);
+    reim4_save_1blk_to_contiguous_reim_ref(m, size, blk_i, dst + offset * nn, dst_tmp);
+  }
+}
+
+/** @brief minimal scratch space byte-size required for the cnv_apply_dft function */
+EXPORT uint64_t fft64_convolution_apply_dft_tmp_bytes(const MODULE* module,                    // N
+                                                      uint64_t res_size, uint64_t res_offset,  // output
+                                                      uint64_t a_size,  // size of left operand (in terms of reim4)
+                                                      uint64_t b_size   // size of right operand (in terms of reim4)
+) {
+  uint64_t size = res_size < a_size + b_size - 1 ? res_size : a_size + b_size - 1;
+  uint64_t offset = res_offset < size ? res_offset : size;
+  return sizeof(double) * 8 * (size - offset);
+}

--- a/spqlios/arithmetic/vec_znx_convolution.c
+++ b/spqlios/arithmetic/vec_znx_convolution.c
@@ -14,8 +14,10 @@ EXPORT void cnv_prepare_right_contiguous(const MODULE* module,                  
 
 /** @brief minimal scratch space byte-size required for the cnv_prepare_right_contiguous function */
 EXPORT uint64_t cnv_prepare_right_contiguous_tmp_bytes(const MODULE* module,  // N
-                                                       uint64_t nrows) {
-  return module->func.cnv_prepare_right_contiguous_tmp_bytes(module, nrows);
+                                                       uint64_t nrows,        // size of output
+                                                       uint64_t a_size        // size of input
+) {
+  return module->func.cnv_prepare_right_contiguous_tmp_bytes(module, nrows, a_size);
 }
 
 /** @brief prepares the right vector for convolution  */
@@ -29,8 +31,10 @@ EXPORT void cnv_prepare_left_contiguous(const MODULE* module,                   
 
 /** @brief minimal scratch space byte-size required for the cnv_prepare_left_contiguous function */
 EXPORT uint64_t cnv_prepare_left_contiguous_tmp_bytes(const MODULE* module,  // N
-                                                      uint64_t nrows) {
-  return module->func.cnv_prepare_left_contiguous_tmp_bytes(module, nrows);
+                                                      uint64_t nrows,        // size of output
+                                                      uint64_t a_size        // size of input
+) {
+  return module->func.cnv_prepare_left_contiguous_tmp_bytes(module, nrows, a_size);
 }
 
 /** @brief prepares the right vector for convolution  */
@@ -44,16 +48,22 @@ EXPORT void fft64_convolution_prepare_right_contiguous_ref(const MODULE* module,
 
 /** @brief minimal scratch space byte-size required for the cnv_prepare_left_contiguous function */
 EXPORT uint64_t fft64_convolution_prepare_left_contiguous_tmp_bytes(const MODULE* module,  // N
-                                                                    uint64_t nrows) {
+                                                                    uint64_t nrows,        // size of output
+                                                                    uint64_t a_size        // size of input
+) {
   const uint64_t nn = module->nn;
-  return nn * sizeof(int64_t) * nrows;
+  const uint64_t rows = nrows < a_size ? nrows : a_size;
+  return nn * sizeof(int64_t) * rows;
 }
 
 /** @brief minimal scratch space byte-size required for the cnv_prepare_right_contiguous function */
 EXPORT uint64_t fft64_convolution_prepare_right_contiguous_tmp_bytes(const MODULE* module,  // N
-                                                                     uint64_t nrows) {
-  const uint64_t nn = module->nn;
-  return nn * sizeof(uint64_t) * nrows;
+                                                                     uint64_t nrows,        // size of output
+                                                                     uint64_t a_size        // size of input
+) {
+  uint64_t nn = module->nn;
+  const uint64_t rows = nrows < a_size ? nrows : a_size;
+  return nn * sizeof(uint64_t) * rows;
 }
 
 /** @brief prepares the left vector for convolution  */

--- a/spqlios/arithmetic/vec_znx_convolution.c
+++ b/spqlios/arithmetic/vec_znx_convolution.c
@@ -114,7 +114,6 @@ EXPORT void fft64_convolution_apply_dft_ref(const MODULE* module,               
                                             uint8_t* tmp_space  // scratch space
 ) {
   const uint64_t m = module->m;
-  const uint64_t nn = module->nn;
   uint64_t size = res_size < a_size + b_size - 1 ? res_size : a_size + b_size - 1;
   uint64_t offset = res_offset < size ? res_offset : size;
 
@@ -126,7 +125,7 @@ EXPORT void fft64_convolution_apply_dft_ref(const MODULE* module,               
   for (uint64_t blk_i = 0; blk_i < m / 4; blk_i++) {
     reim4_convolution_ref(dst_tmp, size, offset, a_double + blk_i * a_size * 8, a_size, b_double + blk_i * b_size * 8,
                           b_size);
-    reim4_save_1blk_to_contiguous_reim_ref(m, size, blk_i, dst + offset * nn, dst_tmp);
+    reim4_save_1blk_to_contiguous_reim_ref(m, size, blk_i, dst, dst_tmp);
   }
 }
 
@@ -137,6 +136,5 @@ EXPORT uint64_t fft64_convolution_apply_dft_tmp_bytes(const MODULE* module,     
                                                       uint64_t b_size   // size of right operand (in terms of reim4)
 ) {
   uint64_t size = res_size < a_size + b_size - 1 ? res_size : a_size + b_size - 1;
-  uint64_t offset = res_offset < size ? res_offset : size;
-  return sizeof(double) * 8 * (size - offset);
+  return sizeof(double) * 8 * size;
 }

--- a/spqlios/arithmetic/vector_matrix_product.c
+++ b/spqlios/arithmetic/vector_matrix_product.c
@@ -39,68 +39,6 @@ EXPORT uint64_t vmp_prepare_contiguous_tmp_bytes(const MODULE* module,  // N
   return module->func.vmp_prepare_contiguous_tmp_bytes(module, nrows, ncols);
 }
 
-/** @brief prepares the right vector for convolution  */
-EXPORT void fft64_convolution_prepare_right_contiguous_ref(const MODULE* module,                              // N
-                                                           CNV_PVEC_R* pvec, uint64_t nrows,                  // output
-                                                           const int64_t* a, uint64_t a_size, uint64_t a_sl,  // a
-                                                           uint8_t* tmp_space  // scratch space
-) {
-  fft64_convolution_prepare_contiguous_ref(module, (double*)pvec, nrows, a, a_size, a_sl, tmp_space);
-}
-
-/** @brief prepares the left vector for convolution  */
-EXPORT void fft64_convolution_prepare_left_contiguous_ref(const MODULE* module,                              // N
-                                                          CNV_PVEC_L* pvec, uint64_t nrows,                  // output
-                                                          const int64_t* a, uint64_t a_size, uint64_t a_sl,  // a
-                                                          uint8_t* tmp_space  // scratch space
-) {
-  fft64_convolution_prepare_contiguous_ref(module, (double*)pvec, nrows, a, a_size, a_sl, tmp_space);
-}
-
-/** @brief prepares a convolution vector  */
-EXPORT void fft64_convolution_prepare_contiguous_ref(const MODULE* module,                              // N
-                                                     double* pvec, uint64_t nrows,                      // output
-                                                     const int64_t* a, uint64_t a_size, uint64_t a_sl,  // a
-                                                     uint8_t* tmp_space                                 // scratch space
-) {
-  const uint64_t m = module->m;
-  const uint64_t rows = nrows < a_size ? nrows : a_size;
-
-  VEC_ZNX_DFT* a_dft = (VEC_ZNX_DFT*)tmp_space;
-
-  fft64_vec_znx_dft(module, a_dft, rows, a, a_size, a_sl);
-
-  for (uint64_t blk_i = 0; blk_i < m / 4; blk_i++) {
-    reim4_extract_1blk_from_contiguous_reim_ref(m, rows, blk_i, pvec + blk_i * rows * 8, (const double*)a_dft);
-  }
-}
-
-/** @brief applies a convolution of two prepared vectors  */
-EXPORT void fft64_convolution_apply_dft_ref(const MODULE* module,                                      // N
-                                            VEC_ZNX_DFT* res, uint64_t res_size, uint64_t res_offset,  // output
-                                            const CNV_PVEC_L* a,
-                                            uint64_t a_size,  // left operand and its size (in terms of reim4)
-                                            const CNV_PVEC_R* b,
-                                            uint64_t b_size,    // right operand and its size (in terms of reim4)
-                                            uint8_t* tmp_space  // scratch space
-) {
-  const uint64_t m = module->m;
-  const uint64_t nn = module->nn;
-  uint64_t size = res_size < a_size + b_size - 1 ? res_size : a_size + b_size - 1;
-  uint64_t offset = res_offset < size ? res_offset : size;
-
-  double* dst_tmp = (double*)tmp_space;
-  double* dst = (double*)res;
-  const double* a_double = (const double*)a;
-  const double* b_double = (const double*)b;
-
-  for (uint64_t blk_i = 0; blk_i < m / 4; blk_i++) {
-    reim4_convolution_ref(dst_tmp, size, offset, a_double + blk_i * a_size * 8, a_size, b_double + blk_i * b_size * 8,
-                          b_size);
-    reim4_save_1blk_to_contiguous_reim_ref(m, size, blk_i, dst + offset * nn, dst_tmp);
-  }
-}
-
 /** @brief prepares a vmp matrix (contiguous row-major version) */
 EXPORT void fft64_vmp_prepare_contiguous_ref(const MODULE* module,                                // N
                                              VMP_PMAT* pmat,                                      // output

--- a/spqlios/arithmetic/vector_matrix_product.c
+++ b/spqlios/arithmetic/vector_matrix_product.c
@@ -39,9 +39,27 @@ EXPORT uint64_t vmp_prepare_contiguous_tmp_bytes(const MODULE* module,  // N
   return module->func.vmp_prepare_contiguous_tmp_bytes(module, nrows, ncols);
 }
 
+/** @brief prepares the right vector for convolution  */
+EXPORT void fft64_convolution_prepare_right_contiguous_ref(const MODULE* module,                              // N
+                                                           CNV_PVEC_R* pvec, uint64_t nrows,                  // output
+                                                           const int64_t* a, uint64_t a_size, uint64_t a_sl,  // a
+                                                           uint8_t* tmp_space  // scratch space
+) {
+  fft64_convolution_prepare_contiguous_ref(module, (double*)pvec, nrows, a, a_size, a_sl, tmp_space);
+}
+
+/** @brief prepares the left vector for convolution  */
+EXPORT void fft64_convolution_prepare_left_contiguous_ref(const MODULE* module,                              // N
+                                                          CNV_PVEC_L* pvec, uint64_t nrows,                  // output
+                                                          const int64_t* a, uint64_t a_size, uint64_t a_sl,  // a
+                                                          uint8_t* tmp_space  // scratch space
+) {
+  fft64_convolution_prepare_contiguous_ref(module, (double*)pvec, nrows, a, a_size, a_sl, tmp_space);
+}
+
 /** @brief prepares a convolution vector  */
 EXPORT void fft64_convolution_prepare_contiguous_ref(const MODULE* module,                              // N
-                                                     VEC_ZNX_DFT* pvec, uint64_t nrows,                 // output
+                                                     double* pvec, uint64_t nrows,                      // output
                                                      const int64_t* a, uint64_t a_size, uint64_t a_sl,  // a
                                                      uint8_t* tmp_space                                 // scratch space
 ) {
@@ -49,12 +67,11 @@ EXPORT void fft64_convolution_prepare_contiguous_ref(const MODULE* module,      
   const uint64_t rows = nrows < a_size ? nrows : a_size;
 
   VEC_ZNX_DFT* a_dft = (VEC_ZNX_DFT*)tmp_space;
-  double* output_vec = (double*)pvec;
 
   fft64_vec_znx_dft(module, a_dft, rows, a, a_size, a_sl);
 
   for (uint64_t blk_i = 0; blk_i < m / 4; blk_i++) {
-    reim4_extract_1blk_from_contiguous_reim_ref(m, rows, blk_i, output_vec + blk_i * rows * 8, (const double*)a_dft);
+    reim4_extract_1blk_from_contiguous_reim_ref(m, rows, blk_i, pvec + blk_i * rows * 8, (const double*)a_dft);
   }
 }
 

--- a/spqlios/commons.c
+++ b/spqlios/commons.c
@@ -112,7 +112,7 @@ double internal_accurate_sin(double x) {
   return rsin;
 }
 
-EXPORT void spqlios_debug_free(void* addr) { free((uint8_t*)addr - 64); }
+EXPORT void spqlios_debug_free(void* addr) { if (addr) free((uint8_t*)addr - 64); }
 
 EXPORT void* spqlios_debug_alloc(uint64_t size) { return (uint8_t*)malloc(size + 64) + 64; }
 

--- a/spqlios/reim4/reim4_arithmetic.h
+++ b/spqlios/reim4/reim4_arithmetic.h
@@ -83,6 +83,17 @@ EXPORT void reim4_extract_1blk_from_reim_avx(uint64_t m, uint64_t blk,
  * @param dst the output: nrows reim4's  dst[i] = src[i](blk)
  * @param src the input: nrows reim's
  */
+EXPORT void reim4_save_1blk_to_contiguous_reim_ref(uint64_t m, uint64_t nrows, uint64_t blk, double* const dst,
+                                                   const double* const src);
+
+/**
+ * @brief extract 1 reim4 block from nrows reim vectors of m complexes
+ * @param nrows the number of reim (fft) vectors
+ * @param m the size of each reim
+ * @param blk the block id to extract (<m/4)
+ * @param dst the output: nrows reim4's  dst[i] = src[i](blk)
+ * @param src the input: nrows reim's
+ */
 EXPORT void reim4_extract_1blk_from_contiguous_reim_ref(uint64_t m, uint64_t nrows, uint64_t blk, double* const dst,
                                                         const double* const src);
 EXPORT void reim4_extract_1blk_from_contiguous_reim_avx(uint64_t m, uint64_t nrows, uint64_t blk, double* const dst,

--- a/spqlios/reim4/reim4_arithmetic_ref.c
+++ b/spqlios/reim4/reim4_arithmetic_ref.c
@@ -22,6 +22,21 @@ void reim4_extract_1blk_from_reim_ref(uint64_t m, uint64_t blk,
   dst[7] = src_ptr[3];
 }
 
+EXPORT void reim4_save_1blk_to_contiguous_reim_ref(uint64_t m, uint64_t nrows, uint64_t blk, double* const dst,
+                                                   const double* const src) {
+  assert(blk < (m >> 2));
+
+  double* dst_ptr = dst + (blk << 2);
+  const double* src_ptr = src;
+  for (uint64_t i = 0; i < nrows * 2; ++i) {
+    dst_ptr[0] = src_ptr[0];
+    dst_ptr[1] = src_ptr[1];
+    dst_ptr[2] = src_ptr[2];
+    dst_ptr[3] = src_ptr[3];
+    src_ptr += 4;
+    dst_ptr += m;
+  }
+}
 EXPORT void reim4_extract_1blk_from_contiguous_reim_ref(uint64_t m, uint64_t nrows, uint64_t blk, double* const dst,
                                                         const double* const src) {
   assert(blk < (m >> 2));

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,6 +84,7 @@ set(UNITTEST_FILES
         spqlios_vec_znx_big_test.cpp
         spqlios_znx_small_test.cpp
         spqlios_vmp_product_test.cpp
+        spqlios_convolution_test.cpp
         spqlios_vec_znx_dft_test.cpp
         spqlios_svp_test.cpp
         spqlios_svp_product_test.cpp

--- a/test/spqlios_convolution_test.cpp
+++ b/test/spqlios_convolution_test.cpp
@@ -1,0 +1,81 @@
+#include <gtest/gtest.h>
+#include <stdint.h>
+
+#include "../spqlios/arithmetic/vec_znx_arithmetic_private.h"
+#include "spqlios/arithmetic/vec_znx_arithmetic.h"
+#include "testlib/fft64_layouts.h"
+#include "testlib/polynomial_vector.h"
+
+static void test_convolution_prepare_contiguous(CNV_PREPARE_RIGHT_CONTIGUOUS_F* prepare_contiguous,
+                                                CNV_PREPARE_RIGHT_CONTIGUOUS_TMP_BYTES_F* tmp_bytes) {
+  // tests when n >= 8
+  for (uint64_t nn : {8, 32}) {
+    MODULE* module = new_module_info(nn, FFT64);
+    uint64_t nblk = nn / 8;
+    for (uint64_t nrows : {1, 2, 5}) {
+      znx_vec_i64_layout vec(nn, nrows, nn);
+      fft64_cnv_right_layout pvec(nn, nrows);
+      vec.fill_random(30);
+      std::vector<uint8_t> tmp_space(tmp_bytes(module, nrows));
+      thash hash_before = vec.content_hash();
+      prepare_contiguous(module, pvec.data, nrows, vec.data(), nrows, nn, tmp_space.data());
+      ASSERT_EQ(vec.content_hash(), hash_before);
+      for (uint64_t row = 0; row < nrows; ++row) {
+        reim_fft64vec tmp = simple_fft64(vec.get_copy(row));
+        for (uint64_t blk = 0; blk < nblk; ++blk) {
+          reim4_elem expect = tmp.get_blk(blk);
+          reim4_elem actual = pvec.get(row, blk);
+          ASSERT_LE(infty_dist(actual, expect), 1e-10);
+        }
+      }
+    }
+    delete_module_info(module);
+  }
+}
+
+TEST(vec_znx, fft64_convolution_prepare_right_contiguous_ref) {
+  test_convolution_prepare_contiguous(fft64_convolution_prepare_right_contiguous_ref,
+                                      fft64_convolution_prepare_right_contiguous_tmp_bytes);
+}
+
+static void test_cnv_apply(CNV_APPLY_DFT_F* apply, CNV_APPLY_DFT_TMP_BYTES_F* tmp_bytes) {
+  for (uint64_t nn : {8, 64}) {
+    MODULE* module = new_module_info(nn, FFT64);
+    for (uint64_t size_l : {1, 4, 7}) {
+      for (uint64_t size_r : {1, 4, 7}) {
+        uint64_t out_size = size_l + size_r - 1;
+        uint64_t offset = 0;
+        fft64_cnv_right_layout pvec_right(nn, size_r);
+        fft64_cnv_left_layout pvec_left(nn, size_l);
+        fft64_vec_znx_dft_layout out(nn, out_size);
+        pvec_right.fill_random(0);
+        pvec_left.fill_random(0);
+        // naive computation of the convolution
+        std::vector<reim_fft64vec> expect(out_size, reim_fft64vec(nn));
+        for (uint64_t k = offset; k < out_size; ++k) {
+          uint64_t jmin = k >= size_l ? k + 1 - size_l : 0;
+          uint64_t jmax = k < size_r ? k + 1 : size_r;
+          reim_fft64vec ex = reim_fft64vec::zero(nn);
+          for (uint64_t j = jmin; j < jmax; ++j) {
+            ex += pvec_left.get_zext(k - j) * pvec_right.get_zext(j);
+          }
+          expect[k] = ex;
+        }
+        //
+        // apply the convolution
+        std::vector<uint8_t> tmp(tmp_bytes(module, out_size, offset, size_l, size_r));
+        apply(module, out.data, out_size, offset, pvec_left.data, size_l, pvec_right.data, size_r, tmp.data());
+        // check that the output is close from the expectation
+        for (uint64_t col = 0; col < out_size; ++col) {
+          reim_fft64vec actual = out.get_copy_zext(col);
+          ASSERT_LE(infty_dist(actual, expect[col]), 1e-10);
+        }
+      }
+    }
+    delete_module_info(module);
+  }
+}
+
+TEST(vec_znx, fft64_convolution_apply_dft_ref) {
+  test_cnv_apply(fft64_convolution_apply_dft_ref, fft64_convolution_apply_dft_tmp_bytes);
+}

--- a/test/spqlios_convolution_test.cpp
+++ b/test/spqlios_convolution_test.cpp
@@ -6,26 +6,31 @@
 #include "testlib/fft64_layouts.h"
 #include "testlib/polynomial_vector.h"
 
-static void test_convolution_prepare_contiguous(CNV_PREPARE_RIGHT_CONTIGUOUS_F* prepare_contiguous,
-                                                CNV_PREPARE_RIGHT_CONTIGUOUS_TMP_BYTES_F* tmp_bytes) {
+template <typename fft64_cnv_layout, typename CNV_PREPARE_CONTIGUOUS_F, typename CNV_PREPARE_CONTIGUOUS_TMP_BYTES_F>
+static void test_convolution_prepare_contiguous(CNV_PREPARE_CONTIGUOUS_F* prepare_contiguous,
+                                                CNV_PREPARE_CONTIGUOUS_TMP_BYTES_F* tmp_bytes) {
   // tests when n >= 8
   for (uint64_t nn : {8, 32}) {
     MODULE* module = new_module_info(nn, FFT64);
     uint64_t nblk = nn / 8;
-    for (uint64_t nrows : {1, 2, 5}) {
-      znx_vec_i64_layout vec(nn, nrows, nn);
-      fft64_cnv_right_layout pvec(nn, nrows);
-      vec.fill_random(30);
-      std::vector<uint8_t> tmp_space(tmp_bytes(module, nrows, nrows));
-      thash hash_before = vec.content_hash();
-      prepare_contiguous(module, pvec.data, nrows, vec.data(), nrows, nn, tmp_space.data());
-      ASSERT_EQ(vec.content_hash(), hash_before);
-      for (uint64_t row = 0; row < nrows; ++row) {
-        reim_fft64vec tmp = simple_fft64(vec.get_copy(row));
-        for (uint64_t blk = 0; blk < nblk; ++blk) {
-          reim4_elem expect = tmp.get_blk(blk);
-          reim4_elem actual = pvec.get(row, blk);
-          ASSERT_LE(infty_dist(actual, expect), 1e-10);
+    for (uint64_t in_nrows : {0, 1, 2, 5}) {
+      for (uint64_t out_nrows : {0, 1, 3, 5}) {
+        znx_vec_i64_layout vec(nn, in_nrows, nn);
+        fft64_cnv_layout pvec(nn, out_nrows);
+        vec.fill_random(30);
+        std::vector<uint8_t> tmp_space(tmp_bytes(module, out_nrows, in_nrows));
+        thash hash_before = vec.content_hash();
+        prepare_contiguous(module,                //
+                           pvec.data, out_nrows,  //
+                           vec.data(), in_nrows, nn, tmp_space.data());
+        ASSERT_EQ(vec.content_hash(), hash_before);
+        for (uint64_t row = 0; row < out_nrows; ++row) {
+          reim_fft64vec tmp = simple_fft64(vec.get_copy_zext(row));
+          for (uint64_t blk = 0; blk < nblk; ++blk) {
+            reim4_elem expect = tmp.get_blk(blk);
+            reim4_elem actual = pvec.get(row, blk);
+            ASSERT_LE(infty_dist(actual, expect), 1e-10);
+          }
         }
       }
     }
@@ -34,46 +39,57 @@ static void test_convolution_prepare_contiguous(CNV_PREPARE_RIGHT_CONTIGUOUS_F* 
 }
 
 TEST(vec_znx, fft64_convolution_prepare_right_contiguous_ref) {
-  test_convolution_prepare_contiguous(fft64_convolution_prepare_right_contiguous_ref,
-                                      fft64_convolution_prepare_right_contiguous_tmp_bytes);
+  test_convolution_prepare_contiguous<fft64_cnv_right_layout,                     //
+                                      CNV_PREPARE_RIGHT_CONTIGUOUS_F,             //
+                                      CNV_PREPARE_RIGHT_CONTIGUOUS_TMP_BYTES_F>(  //
+      fft64_convolution_prepare_right_contiguous_ref,                             //
+      fft64_convolution_prepare_right_contiguous_tmp_bytes);
+}
+
+TEST(vec_znx, fft64_convolution_prepare_left_contiguous_ref) {
+  test_convolution_prepare_contiguous<fft64_cnv_left_layout,                     //
+                                      CNV_PREPARE_LEFT_CONTIGUOUS_F,             //
+                                      CNV_PREPARE_LEFT_CONTIGUOUS_TMP_BYTES_F>(  //
+      fft64_convolution_prepare_left_contiguous_ref,                             //
+      fft64_convolution_prepare_left_contiguous_tmp_bytes);
 }
 
 static void test_cnv_apply(CNV_APPLY_DFT_F* apply, CNV_APPLY_DFT_TMP_BYTES_F* tmp_bytes) {
   for (uint64_t nn : {8, 64}) {
     MODULE* module = new_module_info(nn, FFT64);
-    for (uint64_t size_l : {1, 4, 7}) {
-      for (uint64_t size_r : {1, 4, 7}) {
+    for (uint64_t size_l : {0, 1, 4, 7}) {
+      for (uint64_t size_r : {0, 1, 3, 8}) {
+        fft64_cnv_right_layout pvec_right(nn, size_r);
+        fft64_cnv_left_layout pvec_left(nn, size_l);
+        pvec_right.fill_random(0);
+        pvec_left.fill_random(0);
+        // compute the full convolution vector (leave a leading zero in this test)
+        uint64_t full_cnv_size = size_l + size_r;
+        std::vector<reim_fft64vec> full_convolution(full_cnv_size, reim_fft64vec(nn));
+        for (uint64_t k = 0; k < full_cnv_size; ++k) {
+          full_convolution[k] = reim_fft64vec::zero(nn);
+        }
+        for (uint64_t i = 0; i < size_l; ++i) {
+          for (uint64_t j = 0; j < size_r; ++j) {
+            full_convolution[i + j] += pvec_left.get_zext(i) * pvec_right.get_zext(j);
+          }
+        }
+        // now, test
         for (uint64_t offset : {0, 1, 2}) {
-          uint64_t out_size = size_l + size_r - 1;
-          if (offset > out_size) {
-            continue;
-          }
-          fft64_cnv_right_layout pvec_right(nn, size_r);
-          fft64_cnv_left_layout pvec_left(nn, size_l);
-          fft64_vec_znx_dft_layout out(nn, out_size);
-          pvec_right.fill_random(0);
-          pvec_left.fill_random(0);
-          // naive computation of the convolution
-          std::vector<reim_fft64vec> expect(out_size, reim_fft64vec(nn));
-          for (uint64_t k = offset; k < out_size + offset; ++k) {
-            reim_fft64vec ex = reim_fft64vec::zero(nn);
-            if (k < size_r + size_l) {
-              uint64_t jmin = k >= size_l ? k + 1 - size_l : 0;
-              uint64_t jmax = k < size_r ? k + 1 : size_r;
-              for (uint64_t j = jmin; j < jmax; ++j) {
-                ex += pvec_left.get_zext(k - j) * pvec_right.get_zext(j);
+          for (uint64_t out_size : {0, 1, 2, 3, 4, 5, 6, 7, 8, 13, 14, 15}) {
+            fft64_vec_znx_dft_layout out(nn, out_size);
+            // apply the convolution
+            std::vector<uint8_t> tmp(tmp_bytes(module, out_size, offset, size_l, size_r));
+            apply(module, out.data, out_size, offset, pvec_left.data, size_l, pvec_right.data, size_r, tmp.data());
+            // check the result
+            for (uint64_t k = 0; k < out_size; ++k) {
+              reim_fft64vec actual = out.get_copy_zext(k);
+              reim_fft64vec expect = reim_fft64vec::zero(nn);
+              if (k + offset < full_cnv_size) {
+                expect = full_convolution[k + offset];
               }
+              ASSERT_LE(infty_dist(actual, expect), 1e-10);
             }
-            expect[k - offset] = ex;
-          }
-          //
-          // apply the convolution
-          std::vector<uint8_t> tmp(tmp_bytes(module, out_size, offset, size_l, size_r));
-          apply(module, out.data, out_size, offset, pvec_left.data, size_l, pvec_right.data, size_r, tmp.data());
-          // check that the output is close from the expectation
-          for (uint64_t k = 0; k < out_size; ++k) {
-            reim_fft64vec actual = out.get_copy_zext(k);
-            ASSERT_LE(infty_dist(actual, expect[k]), 1e-10);
           }
         }
       }

--- a/test/spqlios_convolution_test.cpp
+++ b/test/spqlios_convolution_test.cpp
@@ -16,7 +16,7 @@ static void test_convolution_prepare_contiguous(CNV_PREPARE_RIGHT_CONTIGUOUS_F* 
       znx_vec_i64_layout vec(nn, nrows, nn);
       fft64_cnv_right_layout pvec(nn, nrows);
       vec.fill_random(30);
-      std::vector<uint8_t> tmp_space(tmp_bytes(module, nrows));
+      std::vector<uint8_t> tmp_space(tmp_bytes(module, nrows, nrows));
       thash hash_before = vec.content_hash();
       prepare_contiguous(module, pvec.data, nrows, vec.data(), nrows, nn, tmp_space.data());
       ASSERT_EQ(vec.content_hash(), hash_before);

--- a/test/spqlios_reim4_arithmetic_test.cpp
+++ b/test/spqlios_reim4_arithmetic_test.cpp
@@ -281,9 +281,17 @@ TEST(reim4_arithmetic, reim4_vec_convolution_ref) {
         ASSERT_LE(infty_dist(reim4_elem(dest + 8), vexpect[k + 1]), 1e-10);
       }
       // actual convolution
-      reim4_convolution_ref(actual.data(), sizea + sizeb - 1, 0, a.data(), sizea, b.data(), sizeb);
-      for (uint64_t k = 0; k < sizea + sizeb - 1; ++k) {
-        ASSERT_LE(infty_dist(vactual.get(k), vexpect[k]), 1e-10) << k;
+      for (uint64_t offset : {0, 1, 2}) {
+        for (uint64_t out_size : {0, 1, 2, 3, 4, 5, 6, 7, 8, 13, 14, 15}) {
+          std::vector<double> actual(8 * out_size);
+          reim4_array_view vactual(out_size, actual.data());
+          reim4_convolution_ref(actual.data(), out_size, offset, a.data(), sizea, b.data(), sizeb);
+          for (uint64_t k = 0; k < out_size; ++k) {
+            if (k + offset < sizea + sizeb - 1) {
+              ASSERT_LE(infty_dist(vactual.get(k), vexpect[k + offset]), 1e-10) << k;
+            }
+          }
+        }
       }
     }
   }

--- a/test/testlib/fft64_layouts.cpp
+++ b/test/testlib/fft64_layouts.cpp
@@ -224,6 +224,12 @@ reim4_elem fft64_cnv_left_layout::get(uint64_t idx, uint64_t blk) const {
   return reim4_elem(((double*)data) + 8 * (blk * size + idx));
 }
 
+void fft64_cnv_left_layout::set(uint64_t idx, uint64_t blk, const reim4_elem& v) {
+  REQUIRE_DRAMATICALLY(idx < size, "idx overflow: " << idx << " / " << size);
+  REQUIRE_DRAMATICALLY(blk < nn / 8, "block overflow: " << blk << " / " << (nn / 8));
+  v.save_as(((double*)data) + 8 * (blk * size + idx));
+}
+
 reim_fft64vec fft64_cnv_left_layout::get_zext(uint64_t row) const {
   if (row >= size) {
     return reim_fft64vec::zero(nn);
@@ -236,11 +242,16 @@ reim_fft64vec fft64_cnv_left_layout::get_zext(uint64_t row) const {
   return res;
 }
 
-void fft64_cnv_left_layout::set(const reim_fft64vec& value) { value.save_as((double*)data); }
+void fft64_cnv_left_layout::set(uint64_t idx, const reim_fft64vec& value) {
+  REQUIRE_DRAMATICALLY(idx < size, "idx overflow: " << idx << " / " << size);
+  for (uint64_t blk = 0; blk < nn / 8; ++blk) {
+    set(idx, blk, value.get_blk(blk));
+  }
+}
 
 void fft64_cnv_left_layout::fill_random(double log2bound) {
   for (uint64_t row = 0; row < size; ++row) {
-    set(reim_fft64vec::random(nn, log2bound));
+    set(row, reim_fft64vec::random(nn, log2bound));
   }
 }
 
@@ -257,6 +268,12 @@ reim4_elem fft64_cnv_right_layout::get(uint64_t idx, uint64_t blk) const {
   return reim4_elem(((double*)data) + 8 * (blk * size + idx));
 }
 
+void fft64_cnv_right_layout::set(uint64_t idx, uint64_t blk, const reim4_elem& v) {
+  REQUIRE_DRAMATICALLY(idx < size, "idx overflow: " << idx << " / " << size);
+  REQUIRE_DRAMATICALLY(blk < nn / 8, "block overflow: " << blk << " / " << (nn / 8));
+  v.save_as(((double*)data) + 8 * (blk * size + idx));
+}
+
 reim_fft64vec fft64_cnv_right_layout::get_zext(uint64_t row) const {
   if (row >= size) {
     return reim_fft64vec::zero(nn);
@@ -269,11 +286,16 @@ reim_fft64vec fft64_cnv_right_layout::get_zext(uint64_t row) const {
   return res;
 }
 
-void fft64_cnv_right_layout::set(const reim_fft64vec& value) { value.save_as((double*)data); }
+void fft64_cnv_right_layout::set(uint64_t idx, const reim_fft64vec& value) {
+  REQUIRE_DRAMATICALLY(idx < size, "idx overflow: " << idx << " / " << size);
+  for (uint64_t blk = 0; blk < nn / 8; ++blk) {
+    set(idx, blk, value.get_blk(blk));
+  }
+}
 
 void fft64_cnv_right_layout::fill_random(double log2bound) {
   for (uint64_t row = 0; row < size; ++row) {
-    set(reim_fft64vec::random(nn, log2bound));
+    set(row, reim_fft64vec::random(nn, log2bound));
   }
 }
 

--- a/test/testlib/fft64_layouts.h
+++ b/test/testlib/fft64_layouts.h
@@ -86,23 +86,33 @@ class fft64_svp_ppol_layout {
 
 /** @brief test layout for the CNV_PVEC_L */
 class fft64_cnv_left_layout {
+ public:
   const uint64_t nn;
   const uint64_t size;
   CNV_PVEC_L* const data;
   fft64_cnv_left_layout(uint64_t n, uint64_t size);
-  reim4_elem get(uint64_t idx, uint64_t blk);
+  reim4_elem get(uint64_t idx, uint64_t blk) const;
+  void set(const reim_fft64vec&);
+  reim_fft64vec get_zext(uint64_t row) const;
   thash content_hash() const;
+  /** @brief fill with random double values (unstructured) */
+  void fill_random(double log2bound);
   ~fft64_cnv_left_layout();
 };
 
 /** @brief test layout for the CNV_PVEC_R */
 class fft64_cnv_right_layout {
+ public:
   const uint64_t nn;
   const uint64_t size;
   CNV_PVEC_R* const data;
   fft64_cnv_right_layout(uint64_t n, uint64_t size);
-  reim4_elem get(uint64_t idx, uint64_t blk);
+  reim4_elem get(uint64_t idx, uint64_t blk) const;
+  void set(const reim_fft64vec&);
+  reim_fft64vec get_zext(uint64_t row) const;
   thash content_hash() const;
+  /** @brief fill with random double values (unstructured) */
+  void fill_random(double log2bound);
   ~fft64_cnv_right_layout();
 };
 

--- a/test/testlib/fft64_layouts.h
+++ b/test/testlib/fft64_layouts.h
@@ -91,10 +91,11 @@ class fft64_cnv_left_layout {
   const uint64_t size;
   CNV_PVEC_L* const data;
   fft64_cnv_left_layout(uint64_t n, uint64_t size);
-  reim4_elem get(uint64_t idx, uint64_t blk) const;
-  void set(const reim_fft64vec&);
-  reim_fft64vec get_zext(uint64_t row) const;
-  thash content_hash() const;
+  [[nodiscard]] reim4_elem get(uint64_t idx, uint64_t blk) const;
+  void set(uint64_t idx, uint64_t blk, const reim4_elem& v);
+  void set(uint64_t idx, const reim_fft64vec&);
+  [[nodiscard]] reim_fft64vec get_zext(uint64_t idx) const;
+  [[nodiscard]] thash content_hash() const;
   /** @brief fill with random double values (unstructured) */
   void fill_random(double log2bound);
   ~fft64_cnv_left_layout();
@@ -107,10 +108,11 @@ class fft64_cnv_right_layout {
   const uint64_t size;
   CNV_PVEC_R* const data;
   fft64_cnv_right_layout(uint64_t n, uint64_t size);
-  reim4_elem get(uint64_t idx, uint64_t blk) const;
-  void set(const reim_fft64vec&);
-  reim_fft64vec get_zext(uint64_t row) const;
-  thash content_hash() const;
+  [[nodiscard]] reim4_elem get(uint64_t idx, uint64_t blk) const;
+  void set(uint64_t idx, uint64_t blk, const reim4_elem& v);
+  void set(uint64_t idx, const reim_fft64vec&);
+  [[nodiscard]] reim_fft64vec get_zext(uint64_t idx) const;
+  [[nodiscard]] thash content_hash() const;
   /** @brief fill with random double values (unstructured) */
   void fill_random(double log2bound);
   ~fft64_cnv_right_layout();


### PR DESCRIPTION
Addition of the convolution API and one reference implementation (+ tests). 

The reference implementation for now uses the FFT in the X variable and does a naive convolution along Y. 

In this reference implementation, a prepared convolution ZNX vector is computed by taking the FFT of each limb (every ZNX), and then extracting each bulk and storing it contiguously. 

The preparation of left and right vectors is identical. 